### PR TITLE
Add algorithms array now required by `express-jwt`

### DIFF
--- a/api/routes/auth.js
+++ b/api/routes/auth.js
@@ -14,6 +14,7 @@ const getTokenFromHeaders = (req) => {
 const auth = {
   required: jwt({
     secret: process.env.JWT_SECRET,
+    algorithms: ['HS256'],
     userProperty: 'payload',
     getToken: getTokenFromHeaders,
   }),


### PR DESCRIPTION
After #163, this is required for the back end to work!