### PR TITLE
Remove `.gitignore` file from the root of the repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,0 @@
-# Local Netlify folder
-.netlify

--- a/client/.gitignore
+++ b/client/.gitignore
@@ -10,6 +10,7 @@
 
 # production
 /build
+.netlify
 
 # misc
 .DS_Store


### PR DESCRIPTION
After #167, the `.netlify` folder lives in the `client` folder instead of in the root one, so we can move the ignore rule to the client's `.gitignore` file and remove the root's one altogether.