### PR TITLE
Revert "Bump react-avatar-editor from 11.0.9 to 11.0.10 in /client"

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -18178,9 +18178,9 @@
       }
     },
     "react-avatar-editor": {
-      "version": "11.0.10",
-      "resolved": "https://registry.npmjs.org/react-avatar-editor/-/react-avatar-editor-11.0.10.tgz",
-      "integrity": "sha512-Rd5aFuzjsF6cuQUsTXbvd16DVBDUPKNqW6thR+Wmxz7SzQbXI1TvphEC9kZkInnAbZaPwXwo9bpUnDW4jpjf8A==",
+      "version": "11.0.9",
+      "resolved": "https://registry.npmjs.org/react-avatar-editor/-/react-avatar-editor-11.0.9.tgz",
+      "integrity": "sha512-FGYdygcY1ca9PVScHCsm4H28ZLaBPxc/jz2cRhPFjmgMD7fwdYTE5AjBGDCr28jIlRNC1Vm4WERTKxSdDscFDA==",
       "requires": {
         "prop-types": "^15.5.8"
       }

--- a/client/package.json
+++ b/client/package.json
@@ -28,7 +28,7 @@
     "i18next-xhr-backend": "^3.2.2",
     "material-ui-confirm": "^2.1.1",
     "react": "^16.13.1",
-    "react-avatar-editor": "^11.0.10",
+    "react-avatar-editor": "^11.0.9",
     "react-dom": "^16.13.1",
     "react-i18next": "^11.7.0",
     "react-router-dom": "^5.2.0",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -11950,10 +11950,10 @@ react-app-polyfill@^1.0.6:
     regenerator-runtime "^0.13.3"
     whatwg-fetch "^3.0.0"
 
-react-avatar-editor@^11.0.10:
-  version "11.0.10"
-  resolved "https://registry.yarnpkg.com/react-avatar-editor/-/react-avatar-editor-11.0.10.tgz#27fe5de6465a2471d6507626535266b7b444f68c"
-  integrity sha512-Rd5aFuzjsF6cuQUsTXbvd16DVBDUPKNqW6thR+Wmxz7SzQbXI1TvphEC9kZkInnAbZaPwXwo9bpUnDW4jpjf8A==
+react-avatar-editor@^11.0.9:
+  version "11.0.9"
+  resolved "https://registry.yarnpkg.com/react-avatar-editor/-/react-avatar-editor-11.0.9.tgz#74d11f0ccb61dd2aca9c0c1d777d13cfd6ed5530"
+  integrity sha512-FGYdygcY1ca9PVScHCsm4H28ZLaBPxc/jz2cRhPFjmgMD7fwdYTE5AjBGDCr28jIlRNC1Vm4WERTKxSdDscFDA==
   dependencies:
     prop-types "^15.5.8"
 


### PR DESCRIPTION
Reverts Tisn/tisn.app#199 as it's not working (see https://github.com/mosch/react-avatar-editor/issues/340).