### PR TITLE
Pass `req` to `emailConfirmation`

### DIFF
--- a/api/controllers/usersController.js
+++ b/api/controllers/usersController.js
@@ -257,7 +257,7 @@ exports.sendEmailConfirmationEmail = (req, res, next) => {
       return res.sendStatus(404);
     }
 
-    emails.emailConfirmation(foundUser);
+    emails.emailConfirmation(req, foundUser);
 
     res.json({ user: foundUser.toJson() });
   });


### PR DESCRIPTION
I'm not sure where this comes from (maybe #222?), but emails where not being sent because `req` needs to be explicitly passed to `emailConfirmation`.