### PR TITLE
Update Prettier options and re-run it

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -52,7 +52,7 @@
   },
   "lint-staged": {
     "src/**/*.{js,jsx,json,css,md}": [
-      "prettier --single-quote --trailing-comma es5 --write",
+      "prettier --single-quote --write",
       "git add"
     ]
   }

--- a/client/package.json
+++ b/client/package.json
@@ -68,7 +68,7 @@
   },
   "lint-staged": {
     "src/**/*.{js,jsx,json,css,md}": [
-      "prettier --single-quote --trailing-comma es5 --write",
+      "prettier --single-quote --write",
       "git add"
     ]
   }

--- a/client/src/Components/EventSteps/EventSteps.js
+++ b/client/src/Components/EventSteps/EventSteps.js
@@ -197,7 +197,7 @@ const EventSteps = ({ match }) => {
       validationErrors.attendantsLimit;
     const errorInSecondStep = validationErrors.relatedInterests;
 
-    setStepWithError({ '0': errorInFirstStep, '1': errorInSecondStep });
+    setStepWithError({ 0: errorInFirstStep, 1: errorInSecondStep });
 
     if (errorInFirstStep) {
       setActiveStep(0);


### PR DESCRIPTION
The `--trailing-comma es5` option is not needed since [Prettier 2.0 "2020"](https://prettier.io/blog/2020/03/21/2.0.0.html), as it's the default value.

Besides, re-running Prettier on all of the files introduced the change on the `EventSteps` component that I'm committing.