### PR TITLE
Add database population master script

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,12 @@ Before starting, copy the `.env-template` file on the `api` folder to a new `.en
 - `SENDGRID_API_KEY`: you can sign up on [SendGrid](https://sendgrid.com/) using the free tier, however this key is only necessary if you want to send emails, which by default are logged to the console in development mode
 - `BASE_CLIENT_URL`: should be `http://localhost:3000` unless you change the port on which the client runs
 
-Once that's done, you can install all the dependencies and launch the back end executing the following commands from the repository's root folder:
+Once that's done, you can install all the dependencies, populate the database, and launch the back end executing the following commands from the repository's root folder:
 
 ```bash
 cd api
 npm install
+npm run db:populate
 npm start
 ```
 

--- a/api/README.md
+++ b/api/README.md
@@ -2,4 +2,41 @@
 
 The back end is currently hosted on [Heroku](https://heroku.com/).
 
-The production database is currently hosted on [MongoDB Atlas](https://cloud.mongodb.com/). There's a script that can be used to populate the database with interests and users. To run them, use the commands `node db/populate-interests 'MONGODB_URL'` and `node db/populate-users 'MONGODB_URL'` respectively.
+The production database is currently hosted on [MongoDB Atlas](https://cloud.mongodb.com/). There's a script that can be used to populate the database with interests and users. To run the script and to populate all collections, use the command `npm run db:populate`.
+
+## Advanced Options
+
+The following flags can be used when populating the database:
+
+- `-c` or `--collection`, specify the collection you wish to populate.
+- `-m` or `--multiplier`, multiply the default number of users generated.
+- `-r` or `--random-location`, randomizes the country and region each user is located.
+- `-v` or `--verbose`, logs each document generated.
+
+Example:
+
+`npm run db:populate -- -c users -m 5 --verbose`
+
+This example will populate the users collection with 500 users and will log to the console each user created.
+
+When the users collection is first populated it also generates an admin user with the following information:
+
+- Name: Admin
+- Email: admin@tisn.app
+- Password: password
+
+Each user's password generated from the script is `password`.
+
+**Note:** Default number of users generated is 100 and the default location each user is from is Madrid, Spain.
+
+## Deleting Collections
+
+To drop the database, run `npm run db:drop`. This will drop all collections in the database.
+
+The following flags can be used when deleting the database:
+
+- `-c` or `--collection`, specify the collection you wish to delete.
+
+Example:
+
+`npm run db:drop -- -c users`

--- a/api/README.md
+++ b/api/README.md
@@ -2,41 +2,33 @@
 
 The back end is currently hosted on [Heroku](https://heroku.com/).
 
-The production database is currently hosted on [MongoDB Atlas](https://cloud.mongodb.com/). There's a script that can be used to populate the database with interests and users. To run the script and to populate all collections, use the command `npm run db:populate`.
+## Database
 
-## Advanced Options
+The applications uses [MongoDB](https://www.mongodb.com/) and [mongoose](https://mongoosejs.com/). The production database is currently hosted on [MongoDB Atlas](https://cloud.mongodb.com/).
 
-The following flags can be used when populating the database:
+### Populate collections
 
-- `-c` or `--collection`, specify the collection you wish to populate.
-- `-m` or `--multiplier`, multiply the default number of users generated.
-- `-r` or `--random-location`, randomizes the country and region each user is located.
-- `-v` or `--verbose`, logs each document generated.
+There's a script that can be used to populate all the collections with dummy data. Run it with the command `npm run db:populate`.
 
-Example:
+The following arguments can be passed to the script:
 
-`npm run db:populate -- -c users -m 5 --verbose`
+- `-c` or `--collection`, specify the collection you want to populate.
+- `-m` or `--multiplier`, multiply the default number of users generated (100).
+- `-r` or `--random-location`, randomizes the country and region each user is located in. By default, all users are located in Madrid, Spain.
+- `-v` or `--verbose`, logs each generated document to the console.
 
-This example will populate the users collection with 500 users and will log to the console each user created.
+When the users collection is first populated, an admin user with the following information is also generated:
 
-When the users collection is first populated it also generates an admin user with the following information:
+- Name: `Admin`
+- Email: `admin@tisn.app`
+- Password: `password`
 
-- Name: Admin
-- Email: admin@tisn.app
-- Password: password
+All generated users have `password` as their password.
 
-Each user's password generated from the script is `password`.
+### Drop collections
 
-**Note:** Default number of users generated is 100 and the default location each user is from is Madrid, Spain.
+There's also a script that can be used to drop all the collections. Run it with the command `npm run db:drop`.
 
-## Deleting Collections
+The following arguments can be passed to the script:
 
-To drop the database, run `npm run db:drop`. This will drop all collections in the database.
-
-The following flags can be used when deleting the database:
-
-- `-c` or `--collection`, specify the collection you wish to delete.
-
-Example:
-
-`npm run db:drop -- -c users`
+- `-c` or `--collection`, specify the collection you want to drop.

--- a/api/db/db-connection.js
+++ b/api/db/db-connection.js
@@ -3,7 +3,7 @@ const mongoose = require('mongoose');
 const mongoDB = process.env.DB_URL;
 
 const connectMongoDb = () => {
-  console.log('Mongo Db:', mongoDB);
+  console.log('MongoDB URL:', mongoDB);
   mongoose.connect(mongoDB, {
     useNewUrlParser: true,
     useUnifiedTopology: true,
@@ -12,10 +12,10 @@ const connectMongoDb = () => {
   mongoose.Promise = global.Promise;
   const db = mongoose.connection;
   db.on('error', console.error.bind(console, 'MongoDB connection error:'));
-}
+};
 
 const closeMongoDb = () => {
   mongoose.connection.close();
-}
+};
 
-module.exports = {connectMongoDb, closeMongoDb}
+module.exports = { connectMongoDb, closeMongoDb };

--- a/api/db/db-connection.js
+++ b/api/db/db-connection.js
@@ -1,0 +1,21 @@
+require('dotenv').config();
+const mongoose = require('mongoose');
+const mongoDB = process.env.DB_URL;
+
+const connectMongoDb = () => {
+  console.log('Mongo Db:', mongoDB);
+  mongoose.connect(mongoDB, {
+    useNewUrlParser: true,
+    useUnifiedTopology: true,
+    useCreateIndex: true,
+  });
+  mongoose.Promise = global.Promise;
+  const db = mongoose.connection;
+  db.on('error', console.error.bind(console, 'MongoDB connection error:'));
+}
+
+const closeMongoDb = () => {
+  mongoose.connection.close();
+}
+
+module.exports = {connectMongoDb, closeMongoDb}

--- a/api/db/drop.js
+++ b/api/db/drop.js
@@ -1,0 +1,50 @@
+#! /usr/bin/env node
+
+const minimist = require('minimist');
+const Interest = require('../models/Interest');
+const User = require('../models/User');
+const { connectMongoDb, closeMongoDb } = require('./db-connection');
+
+const userArgs = minimist(process.argv.slice(2), {
+  string: 'collection',
+  alias: {
+    c: 'collection',
+  },
+});
+
+const dropInterests = async () => {
+  console.log('Dropping interests collection...');
+  if ((await Interest.countDocuments()) !== 0) await Interest.collection.drop();
+};
+
+const dropUsers = async () => {
+  console.log('Dropping users collection...');
+  if ((await User.countDocuments()) !== 0) await User.collection.drop();
+};
+
+const deleteCollections = async () => {
+  connectMongoDb();
+  await dropInterests();
+  await dropUsers();
+  closeMongoDb();
+};
+
+const deleteCollection = async () => {
+  connectMongoDb();
+  switch (userArgs.c.toLowerCase()) {
+    case 'interests':
+      await dropInterests();
+      break;
+    case 'users':
+      await dropUsers();
+      break;
+    default:
+      console.log(
+        `Unknown collection '${userArgs.c}', possible options are: [interests, users]`
+      );
+      break;
+  }
+  closeMongoDb();
+};
+
+userArgs.c ? deleteCollection() : deleteCollections();

--- a/api/db/drop.js
+++ b/api/db/drop.js
@@ -1,9 +1,10 @@
 #! /usr/bin/env node
 
 const minimist = require('minimist');
+const { connectMongoDb, closeMongoDb } = require('./db-connection');
+
 const Interest = require('../models/Interest');
 const User = require('../models/User');
-const { connectMongoDb, closeMongoDb } = require('./db-connection');
 
 const userArgs = minimist(process.argv.slice(2), {
   string: 'collection',
@@ -13,23 +14,33 @@ const userArgs = minimist(process.argv.slice(2), {
 });
 
 const dropInterests = async () => {
-  console.log('Dropping interests collection...');
-  if ((await Interest.countDocuments()) !== 0) await Interest.collection.drop();
+  console.log('\n', '\x1b[0m', 'Dropping interests collection...');
+  if ((await Interest.countDocuments()) !== 0) {
+    await Interest.collection.drop();
+    console.log('\x1b[31m', 'Dropped interests collection');
+  } else {
+    console.log('\x1b[33m', 'Interests collection is already empty');
+  }
 };
 
 const dropUsers = async () => {
-  console.log('Dropping users collection...');
-  if ((await User.countDocuments()) !== 0) await User.collection.drop();
+  console.log('\n', '\x1b[0m', 'Dropping users collection...');
+  if ((await User.countDocuments()) !== 0) {
+    await User.collection.drop();
+    console.log('\x1b[31m', 'Dropped users collection');
+  } else {
+    console.log('\x1b[33m', 'Users collection is already empty');
+  }
 };
 
-const deleteCollections = async () => {
+const dropCollections = async () => {
   connectMongoDb();
   await dropInterests();
   await dropUsers();
   closeMongoDb();
 };
 
-const deleteCollection = async () => {
+const dropCollection = async () => {
   connectMongoDb();
   switch (userArgs.c.toLowerCase()) {
     case 'interests':
@@ -47,4 +58,4 @@ const deleteCollection = async () => {
   closeMongoDb();
 };
 
-userArgs.c ? deleteCollection() : deleteCollections();
+userArgs.c ? dropCollection() : dropCollections();

--- a/api/db/populate-interests.js
+++ b/api/db/populate-interests.js
@@ -19,7 +19,7 @@ const createInterest = async (name, avatar, category) => {
 };
 
 const createInterests = async (verbose) => {
-  console.log('Populating interests...');
+  console.log('\x1b[0m', 'Populating interests...');
   displayLogs = verbose;
 
   if ((await Interest.countDocuments()) !== 0) await Interest.collection.drop();
@@ -690,7 +690,7 @@ const createInterests = async (verbose) => {
     categories[5]
   );
 
-  console.log(`Interests created: ${interests.length}`);
+  console.log('\x1b[32m', `Interests created: ${interests.length}`);
 };
 
 module.exports = { createInterests };

--- a/api/db/populate-interests.js
+++ b/api/db/populate-interests.js
@@ -16,12 +16,15 @@ let displayLogs;
 const createInterest = async (name, avatar, category) => {
   const interest = new Interest({ name, avatar, category });
   await interest.save();
-  if (displayLogs) console.log(`New interest: ${interest}`);
   interests.push(interest);
+
+  if (displayLogs) {
+    console.log('\n', '\x1b[0m', `New interest created: ${interest}`);
+  }
 };
 
 const createInterests = async (verbose) => {
-  console.log('\x1b[0m', 'Populating interests...');
+  console.log('\n', '\x1b[0m', 'Populating interests collection...');
   displayLogs = verbose;
 
   if ((await Interest.countDocuments()) !== 0) {
@@ -29,679 +32,586 @@ const createInterests = async (verbose) => {
       type: 'confirm',
       name: 'value',
       message:
-        'The interests collection already contains some documents. It is recommended that you drop the existing collection before proceeding to avoid duplication. Would you like to drop the existing collection before proceeding?',
+        'The interests collection already exists. If you continue, the existing collection will be dropped to avoid duplication. Please note that this can break your application. Do you want to continue?',
       initial: true,
     });
-    if (answer.value) await Interest.collection.drop();
+    if (answer.value) {
+      await Interest.collection.drop();
+      console.log('\x1b[31m', 'Dropped old interests collection');
+    } else {
+      console.log('\x1b[33m', 'Aborted interests collection population');
+      return;
+    }
   }
 
+  // Entertainment category
   await createInterest(
     'Art',
     'https://image.flaticon.com/icons/svg/2811/2811172.svg',
     categories[0]
   );
-
   await createInterest(
     'Ballet',
     'https://image.flaticon.com/icons/png/512/1844/1844042.png',
     categories[0]
   );
-
   await createInterest(
     'Bars',
     'https://image.flaticon.com/icons/svg/742/742096.svg',
     categories[0]
   );
-
   await createInterest(
     'Board games',
     'https://image.flaticon.com/icons/png/512/2740/2740984.png',
     categories[0]
   );
-
   await createInterest(
     'Comics',
     'https://image.flaticon.com/icons/svg/2628/2628930.svg',
     categories[0]
   );
-
   await createInterest(
     'Concerts',
     'https://image.flaticon.com/icons/png/512/1789/1789786.png',
     categories[0]
   );
-
   await createInterest(
     'Festivals',
     'https://image.flaticon.com/icons/png/512/2406/2406687.png',
     categories[0]
   );
-
   await createInterest(
     'Games',
     'https://image.flaticon.com/icons/svg/744/744737.svg',
     categories[0]
   );
-
   await createInterest(
     'Literature',
     'https://image.flaticon.com/icons/svg/2599/2599249.svg',
     categories[0]
   );
-
   await createInterest(
     'Magazines',
     'https://image.flaticon.com/icons/svg/653/653014.svg',
     categories[0]
   );
-
   await createInterest(
     'Movies',
     'https://image.flaticon.com/icons/svg/2824/2824516.svg',
     categories[0]
   );
-
   await createInterest(
     'Music',
     'https://image.flaticon.com/icons/svg/651/651758.svg',
     categories[0]
   );
-
   await createInterest(
     'News',
     'https://image.flaticon.com/icons/svg/1825/1825151.svg',
     categories[0]
   );
-
   await createInterest(
     'Night clubs',
     'https://image.flaticon.com/icons/svg/1930/1930684.svg',
     categories[0]
   );
-
   await createInterest(
     'Reading',
     'https://image.flaticon.com/icons/svg/2599/2599411.svg',
     categories[0]
   );
-
   await createInterest(
     'Series',
     'https://image.flaticon.com/icons/svg/2881/2881114.svg',
     categories[0]
   );
-
   await createInterest(
     'Theatre',
     'https://image.flaticon.com/icons/svg/2061/2061056.svg',
     categories[0]
   );
 
+  // Fitness and wellness category
   await createInterest(
     'Bodybuilding',
     'https://image.flaticon.com/icons/png/512/2307/2307905.png',
     categories[1]
   );
-
   await createInterest(
     'Fitness',
     'https://image.flaticon.com/icons/svg/2307/2307959.svg',
     categories[1]
   );
-
   await createInterest(
     'Meditation',
     'https://image.flaticon.com/icons/png/512/2781/2781698.png',
     categories[1]
   );
-
   await createInterest(
     'Weightlifting',
     'https://image.flaticon.com/icons/svg/2307/2307879.svg',
     categories[1]
   );
-
   await createInterest(
     'Yoga',
     'https://image.flaticon.com/icons/svg/2307/2307981.svg',
     categories[1]
   );
 
+  // Hobbies and activities category
   await createInterest(
     'Acting',
     'https://image.flaticon.com/icons/svg/2636/2636923.svg',
     categories[2]
   );
-
   await createInterest(
     'Automobiles',
     'https://image.flaticon.com/icons/svg/500/500707.svg',
     categories[2]
   );
-
   await createInterest(
     'Charity',
     'https://image.flaticon.com/icons/svg/838/838618.svg',
     categories[2]
   );
-
   await createInterest(
     'Chat',
     'https://image.flaticon.com/icons/svg/509/509535.svg',
     categories[2]
   );
-
   await createInterest(
     'Cooking',
     'https://image.flaticon.com/icons/svg/2863/2863411.svg',
     categories[2]
   );
-
   await createInterest(
     'Crafts',
     'https://image.flaticon.com/icons/svg/2611/2611210.svg',
     categories[2]
   );
-
   await createInterest(
     'Dance',
     'https://image.flaticon.com/icons/svg/498/498377.svg',
     categories[2]
   );
-
   await createInterest(
     'Furniture',
     'https://image.flaticon.com/icons/svg/2610/2610836.svg',
     categories[2]
   );
-
   await createInterest(
     'Gardening',
     'https://image.flaticon.com/icons/svg/2824/2824501.svg',
     categories[2]
   );
-
   await createInterest(
     'Motorcycles',
     'https://image.flaticon.com/icons/svg/519/519598.svg',
     categories[2]
   );
-
   await createInterest(
     'Nature',
     'https://image.flaticon.com/icons/svg/2899/2899987.svg',
     categories[2]
   );
-
   await createInterest(
     'Painting',
     'https://image.flaticon.com/icons/svg/2736/2736499.svg',
     categories[2]
   );
-
   await createInterest(
     'Pets',
     'https://image.flaticon.com/icons/svg/2064/2064863.svg',
     categories[2]
   );
-
   await createInterest(
     'Photography',
     'https://image.flaticon.com/icons/svg/2636/2636410.svg',
     categories[2]
   );
-
   await createInterest(
     'Politics',
     'https://image.flaticon.com/icons/svg/1672/1672268.svg',
     categories[2]
   );
-
   await createInterest(
     'Religion',
     'https://image.flaticon.com/icons/svg/2242/2242222.svg',
     categories[2]
   );
-
   await createInterest(
     'Sculpture',
     'https://image.flaticon.com/icons/png/512/2579/2579979.png',
     categories[2]
   );
-
   await createInterest(
     'Singing',
     'https://image.flaticon.com/icons/svg/1974/1974848.svg',
     categories[2]
   );
-
   await createInterest(
     'Sustainability',
     'https://image.flaticon.com/icons/svg/2371/2371903.svg',
     categories[2]
   );
-
   await createInterest(
     'Theme parks',
     'https://image.flaticon.com/icons/png/512/2809/2809645.png',
     categories[2]
   );
-
   await createInterest(
     'Travel',
     'https://image.flaticon.com/icons/svg/1175/1175017.svg',
     categories[2]
   );
-
   await createInterest(
     'Vacations',
     'https://image.flaticon.com/icons/svg/1209/1209425.svg',
     categories[2]
   );
-
   await createInterest(
     'Volunteering',
     'https://image.flaticon.com/icons/svg/2634/2634501.svg',
     categories[2]
   );
-
   await createInterest(
     'Writing',
     'https://image.flaticon.com/icons/svg/1830/1830934.svg',
     categories[2]
   );
 
+  // Industry and business category
   await createInterest(
     'Advertising',
     'https://image.flaticon.com/icons/svg/2787/2787828.svg',
     categories[3]
   );
-
   await createInterest(
     'Agriculture',
     'https://image.flaticon.com/icons/svg/2708/2708842.svg',
     categories[3]
   );
-
   await createInterest(
     'Architecture',
     'https://image.flaticon.com/icons/svg/2771/2771336.svg',
     categories[3]
   );
-
   await createInterest(
     'Aviation',
     'https://image.flaticon.com/icons/svg/2302/2302811.svg',
     categories[3]
   );
-
   await createInterest(
     'Business',
     'https://image.flaticon.com/icons/svg/1162/1162489.svg',
     categories[3]
   );
-
   await createInterest(
     'Construction',
     'https://image.flaticon.com/icons/svg/819/819392.svg',
     categories[3]
   );
-
   await createInterest(
     'Design',
     'https://image.flaticon.com/icons/svg/802/802033.svg',
     categories[3]
   );
-
   await createInterest(
     'Economics',
     'https://image.flaticon.com/icons/svg/2179/2179261.svg',
     categories[3]
   );
-
   await createInterest(
     'Education',
     'https://image.flaticon.com/icons/svg/2681/2681857.svg',
     categories[3]
   );
-
   await createInterest(
     'Engineering',
     'https://image.flaticon.com/icons/svg/897/897168.svg',
     categories[3]
   );
-
   await createInterest(
     'Entrepreneurship',
     'https://image.flaticon.com/icons/svg/1535/1535019.svg',
     categories[3]
   );
-
   await createInterest(
     'Health care',
     'https://image.flaticon.com/icons/svg/1021/1021606.svg',
     categories[3]
   );
-
   await createInterest(
     'Insurance',
     'https://image.flaticon.com/icons/svg/2754/2754975.svg',
     categories[3]
   );
-
   await createInterest(
     'Investment',
     'https://image.flaticon.com/icons/svg/2474/2474455.svg',
     categories[3]
   );
-
   await createInterest(
     'Law',
     'https://image.flaticon.com/icons/svg/1208/1208198.svg',
     categories[3]
   );
-
   await createInterest(
     'Management',
     'https://image.flaticon.com/icons/svg/1208/1208203.svg',
     categories[3]
   );
-
   await createInterest(
     'Marketing',
     'https://image.flaticon.com/icons/svg/1378/1378593.svg',
     categories[3]
   );
-
   await createInterest(
     'Real estate',
     'https://image.flaticon.com/icons/svg/602/602175.svg',
     categories[3]
   );
-
   await createInterest(
     'Retail',
     'https://image.flaticon.com/icons/svg/1198/1198361.svg',
     categories[3]
   );
-
   await createInterest(
     'Sales',
     'https://image.flaticon.com/icons/svg/1312/1312187.svg',
     categories[3]
   );
-
   await createInterest(
     'Science',
     'https://image.flaticon.com/icons/svg/2784/2784451.svg',
     categories[3]
   );
-
   await createInterest(
     'Social media',
     'https://image.flaticon.com/icons/svg/2065/2065203.svg',
     categories[3]
   );
-
   await createInterest(
     'Software',
     'https://image.flaticon.com/icons/svg/1149/1149168.svg',
     categories[3]
   );
 
+  // Shopping and fashion category
   await createInterest(
     'Beauty salons',
     'https://image.flaticon.com/icons/svg/1940/1940922.svg',
     categories[4]
   );
-
   await createInterest(
     'Boutiques',
     'https://image.flaticon.com/icons/svg/1719/1719625.svg',
     categories[4]
   );
-
   await createInterest(
     'Clothing',
     'https://image.flaticon.com/icons/svg/2794/2794012.svg',
     categories[4]
   );
-
   await createInterest(
     'Cosmetics',
     'https://image.flaticon.com/icons/svg/545/545159.svg',
     categories[4]
   );
-
   await createInterest(
     'Coupons',
     'https://image.flaticon.com/icons/svg/423/423809.svg',
     categories[4]
   );
-
   await createInterest(
     'Discount stores',
     'https://image.flaticon.com/icons/svg/411/411807.svg',
     categories[4]
   );
-
   await createInterest(
     'Fragrances',
     'https://image.flaticon.com/icons/svg/2611/2611095.svg',
     categories[4]
   );
-
   await createInterest(
     'Hairdressing',
     'https://image.flaticon.com/icons/svg/393/393164.svg',
     categories[4]
   );
-
   await createInterest(
     'Handbags',
     'https://image.flaticon.com/icons/svg/679/679997.svg',
     categories[4]
   );
-
   await createInterest(
     'Jewelry',
     'https://image.flaticon.com/icons/svg/703/703280.svg',
     categories[4]
   );
-
   await createInterest(
     'Piercings',
     'https://image.flaticon.com/icons/svg/1686/1686352.svg',
     categories[4]
   );
-
   await createInterest(
     'Shoes',
     'https://image.flaticon.com/icons/svg/1940/1940912.svg',
     categories[4]
   );
-
   await createInterest(
     'Shopping malls',
     'https://image.flaticon.com/icons/svg/1057/1057313.svg',
     categories[4]
   );
-
   await createInterest(
     'Spas',
     'https://image.flaticon.com/icons/svg/2770/2770760.svg',
     categories[4]
   );
-
   await createInterest(
     'Sunglasses',
     'https://image.flaticon.com/icons/svg/399/399745.svg',
     categories[4]
   );
-
   await createInterest(
     'Tattoos',
     'https://image.flaticon.com/icons/svg/1686/1686442.svg',
     categories[4]
   );
-
   await createInterest(
     'Toys',
     'https://image.flaticon.com/icons/svg/522/522043.svg',
     categories[4]
   );
 
+  // Sports category
   await createInterest(
     'American football',
     'https://image.flaticon.com/icons/svg/625/625369.svg',
     categories[5]
   );
-
   await createInterest(
     'Baseball',
     'https://image.flaticon.com/icons/svg/484/484482.svg',
     categories[5]
   );
-
   await createInterest(
     'Basketball',
     'https://image.flaticon.com/icons/svg/500/500245.svg',
     categories[5]
   );
-
   await createInterest(
     'Bowling',
     'https://image.flaticon.com/icons/svg/2438/2438473.svg',
     categories[5]
   );
-
   await createInterest(
     'Boxing',
     'https://image.flaticon.com/icons/svg/418/418171.svg',
     categories[5]
   );
-
   await createInterest(
     'Chess',
     'https://image.flaticon.com/icons/svg/2633/2633894.svg',
     categories[5]
   );
-
   await createInterest(
     'Cycling',
     'https://image.flaticon.com/icons/svg/2906/2906833.svg',
     categories[5]
   );
-
   await createInterest(
     'Esports',
     'https://image.flaticon.com/icons/svg/2285/2285714.svg',
     categories[5]
   );
-
   await createInterest(
     'Fishing',
     'https://image.flaticon.com/icons/svg/1830/1830797.svg',
     categories[5]
   );
-
   await createInterest(
     'Football',
     'https://image.flaticon.com/icons/svg/2784/2784491.svg',
     categories[5]
   );
-
   await createInterest(
     'Golf',
     'https://image.flaticon.com/icons/svg/491/491972.svg',
     categories[5]
   );
-
   await createInterest(
     'Martial arts',
     'https://image.flaticon.com/icons/svg/625/625357.svg',
     categories[5]
   );
-
   await createInterest(
     'Ping pong',
     'https://image.flaticon.com/icons/svg/866/866748.svg',
     categories[5]
   );
-
   await createInterest(
     'Poker',
     'https://image.flaticon.com/icons/svg/867/867864.svg',
     categories[5]
   );
-
   await createInterest(
     'Racing',
     'https://image.flaticon.com/icons/svg/469/469122.svg',
     categories[5]
   );
-
   await createInterest(
     'Running',
     'https://image.flaticon.com/icons/svg/2460/2460093.svg',
     categories[5]
   );
-
   await createInterest(
     'Sailing',
     'https://image.flaticon.com/icons/svg/434/434077.svg',
     categories[5]
   );
-
   await createInterest(
     'Skiing',
     'https://image.flaticon.com/icons/svg/625/625360.svg',
     categories[5]
   );
-
   await createInterest(
     'Snowboarding',
     'https://image.flaticon.com/icons/svg/2592/2592838.svg',
     categories[5]
   );
-
   await createInterest(
     'Speedcubing',
     'https://image.flaticon.com/icons/svg/522/522052.svg',
     categories[5]
   );
-
   await createInterest(
     'Surfing',
     'https://image.flaticon.com/icons/svg/2768/2768580.svg',
     categories[5]
   );
-
   await createInterest(
     'Swimming',
     'https://image.flaticon.com/icons/svg/495/495821.svg',
     categories[5]
   );
-
   await createInterest(
     'Tennis',
     'https://image.flaticon.com/icons/svg/802/802289.svg',
     categories[5]
   );
-
   await createInterest(
     'Volleyball',
     'https://image.flaticon.com/icons/svg/2906/2906725.svg',
     categories[5]
   );
-
   await createInterest(
     'Waterpolo',
     'https://image.flaticon.com/icons/svg/495/495843.svg',
     categories[5]
   );
 
-  console.log('\x1b[32m', `Interests created: ${interests.length}`);
+  console.log('\x1b[32m', `Created ${interests.length} interests`);
 };
 
 module.exports = { createInterests };

--- a/api/db/populate-interests.js
+++ b/api/db/populate-interests.js
@@ -1,29 +1,4 @@
-#! /usr/bin/env node
-
-const userArgs = process.argv.slice(2);
-
-if (!userArgs[0].startsWith('mongodb')) {
-  console.log(
-    'Error: you need to specify a valid MongoDB URL as the first argument'
-  );
-
-  return;
-}
-
 const Interest = require('../models/Interest');
-
-const async = require('async');
-
-const mongoose = require('mongoose');
-const mongoDB = userArgs[0];
-mongoose.connect(mongoDB, {
-  useNewUrlParser: true,
-  useUnifiedTopology: true,
-  useCreateIndex: true,
-});
-mongoose.Promise = global.Promise;
-const db = mongoose.connection;
-db.on('error', console.error.bind(console, 'MongoDB connection error:'));
 
 const categories = [
   'Entertainment',
@@ -34,924 +9,690 @@ const categories = [
   'Sports',
 ];
 const interests = [];
+let displayLogs;
 
-const createInterest = (name, avatar, category, callback) => {
+const createInterest = async (name, avatar, category) => {
   const interest = new Interest({ name, avatar, category });
-
-  interest.save().then(() => {
-    console.log(`New interest: ${interest}`);
-    interests.push(interest);
-    callback(null, interest);
-  });
+  await interest.save();
+  if (displayLogs) console.log(`New interest: ${interest}`);
+  interests.push(interest);
 };
 
-const createInterests = () => {
-  async.series(
-    [
-      (seriesCallback) => {
-        createInterest(
-          'Art',
-          'https://image.flaticon.com/icons/svg/2811/2811172.svg',
-          categories[0],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Ballet',
-          'https://image.flaticon.com/icons/png/512/1844/1844042.png',
-          categories[0],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Bars',
-          'https://image.flaticon.com/icons/svg/742/742096.svg',
-          categories[0],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Board games',
-          'https://image.flaticon.com/icons/png/512/2740/2740984.png',
-          categories[0],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Comics',
-          'https://image.flaticon.com/icons/svg/2628/2628930.svg',
-          categories[0],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Concerts',
-          'https://image.flaticon.com/icons/png/512/1789/1789786.png',
-          categories[0],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Festivals',
-          'https://image.flaticon.com/icons/png/512/2406/2406687.png',
-          categories[0],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Games',
-          'https://image.flaticon.com/icons/svg/744/744737.svg',
-          categories[0],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Literature',
-          'https://image.flaticon.com/icons/svg/2599/2599249.svg',
-          categories[0],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Magazines',
-          'https://image.flaticon.com/icons/svg/653/653014.svg',
-          categories[0],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Movies',
-          'https://image.flaticon.com/icons/svg/2824/2824516.svg',
-          categories[0],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Music',
-          'https://image.flaticon.com/icons/svg/651/651758.svg',
-          categories[0],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'News',
-          'https://image.flaticon.com/icons/svg/1825/1825151.svg',
-          categories[0],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Night clubs',
-          'https://image.flaticon.com/icons/svg/1930/1930684.svg',
-          categories[0],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Reading',
-          'https://image.flaticon.com/icons/svg/2599/2599411.svg',
-          categories[0],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Series',
-          'https://image.flaticon.com/icons/svg/2881/2881114.svg',
-          categories[0],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Theatre',
-          'https://image.flaticon.com/icons/svg/2061/2061056.svg',
-          categories[0],
-          seriesCallback
-        );
-      },
-
-      (seriesCallback) => {
-        createInterest(
-          'Bodybuilding',
-          'https://image.flaticon.com/icons/png/512/2307/2307905.png',
-          categories[1],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Fitness',
-          'https://image.flaticon.com/icons/svg/2307/2307959.svg',
-          categories[1],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Meditation',
-          'https://image.flaticon.com/icons/png/512/2781/2781698.png',
-          categories[1],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Weightlifting',
-          'https://image.flaticon.com/icons/svg/2307/2307879.svg',
-          categories[1],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Yoga',
-          'https://image.flaticon.com/icons/svg/2307/2307981.svg',
-          categories[1],
-          seriesCallback
-        );
-      },
-
-      (seriesCallback) => {
-        createInterest(
-          'Acting',
-          'https://image.flaticon.com/icons/svg/2636/2636923.svg',
-          categories[2],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Automobiles',
-          'https://image.flaticon.com/icons/svg/500/500707.svg',
-          categories[2],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Charity',
-          'https://image.flaticon.com/icons/svg/838/838618.svg',
-          categories[2],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Chat',
-          'https://image.flaticon.com/icons/svg/509/509535.svg',
-          categories[2],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Cooking',
-          'https://image.flaticon.com/icons/svg/2863/2863411.svg',
-          categories[2],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Crafts',
-          'https://image.flaticon.com/icons/svg/2611/2611210.svg',
-          categories[2],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Dance',
-          'https://image.flaticon.com/icons/svg/498/498377.svg',
-          categories[2],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Furniture',
-          'https://image.flaticon.com/icons/svg/2610/2610836.svg',
-          categories[2],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Gardening',
-          'https://image.flaticon.com/icons/svg/2824/2824501.svg',
-          categories[2],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Motorcycles',
-          'https://image.flaticon.com/icons/svg/519/519598.svg',
-          categories[2],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Nature',
-          'https://image.flaticon.com/icons/svg/2899/2899987.svg',
-          categories[2],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Painting',
-          'https://image.flaticon.com/icons/svg/2736/2736499.svg',
-          categories[2],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Pets',
-          'https://image.flaticon.com/icons/svg/2064/2064863.svg',
-          categories[2],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Photography',
-          'https://image.flaticon.com/icons/svg/2636/2636410.svg',
-          categories[2],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Politics',
-          'https://image.flaticon.com/icons/svg/1672/1672268.svg',
-          categories[2],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Religion',
-          'https://image.flaticon.com/icons/svg/2242/2242222.svg',
-          categories[2],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Sculpture',
-          'https://image.flaticon.com/icons/png/512/2579/2579979.png',
-          categories[2],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Singing',
-          'https://image.flaticon.com/icons/svg/1974/1974848.svg',
-          categories[2],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Sustainability',
-          'https://image.flaticon.com/icons/svg/2371/2371903.svg',
-          categories[2],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Theme parks',
-          'https://image.flaticon.com/icons/png/512/2809/2809645.png',
-          categories[2],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Travel',
-          'https://image.flaticon.com/icons/svg/1175/1175017.svg',
-          categories[2],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Vacations',
-          'https://image.flaticon.com/icons/svg/1209/1209425.svg',
-          categories[2],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Volunteering',
-          'https://image.flaticon.com/icons/svg/2634/2634501.svg',
-          categories[2],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Writing',
-          'https://image.flaticon.com/icons/svg/1830/1830934.svg',
-          categories[2],
-          seriesCallback
-        );
-      },
-
-      (seriesCallback) => {
-        createInterest(
-          'Advertising',
-          'https://image.flaticon.com/icons/svg/2787/2787828.svg',
-          categories[3],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Agriculture',
-          'https://image.flaticon.com/icons/svg/2708/2708842.svg',
-          categories[3],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Architecture',
-          'https://image.flaticon.com/icons/svg/2771/2771336.svg',
-          categories[3],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Aviation',
-          'https://image.flaticon.com/icons/svg/2302/2302811.svg',
-          categories[3],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Business',
-          'https://image.flaticon.com/icons/svg/1162/1162489.svg',
-          categories[3],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Construction',
-          'https://image.flaticon.com/icons/svg/819/819392.svg',
-          categories[3],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Design',
-          'https://image.flaticon.com/icons/svg/802/802033.svg',
-          categories[3],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Economics',
-          'https://image.flaticon.com/icons/svg/2179/2179261.svg',
-          categories[3],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Education',
-          'https://image.flaticon.com/icons/svg/2681/2681857.svg',
-          categories[3],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Engineering',
-          'https://image.flaticon.com/icons/svg/897/897168.svg',
-          categories[3],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Entrepreneurship',
-          'https://image.flaticon.com/icons/svg/1535/1535019.svg',
-          categories[3],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Health care',
-          'https://image.flaticon.com/icons/svg/1021/1021606.svg',
-          categories[3],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Insurance',
-          'https://image.flaticon.com/icons/svg/2754/2754975.svg',
-          categories[3],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Investment',
-          'https://image.flaticon.com/icons/svg/2474/2474455.svg',
-          categories[3],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Law',
-          'https://image.flaticon.com/icons/svg/1208/1208198.svg',
-          categories[3],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Management',
-          'https://image.flaticon.com/icons/svg/1208/1208203.svg',
-          categories[3],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Marketing',
-          'https://image.flaticon.com/icons/svg/1378/1378593.svg',
-          categories[3],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Real estate',
-          'https://image.flaticon.com/icons/svg/602/602175.svg',
-          categories[3],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Retail',
-          'https://image.flaticon.com/icons/svg/1198/1198361.svg',
-          categories[3],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Sales',
-          'https://image.flaticon.com/icons/svg/1312/1312187.svg',
-          categories[3],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Science',
-          'https://image.flaticon.com/icons/svg/2784/2784451.svg',
-          categories[3],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Social media',
-          'https://image.flaticon.com/icons/svg/2065/2065203.svg',
-          categories[3],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Software',
-          'https://image.flaticon.com/icons/svg/1149/1149168.svg',
-          categories[3],
-          seriesCallback
-        );
-      },
-
-      (seriesCallback) => {
-        createInterest(
-          'Beauty salons',
-          'https://image.flaticon.com/icons/svg/1940/1940922.svg',
-          categories[4],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Boutiques',
-          'https://image.flaticon.com/icons/svg/1719/1719625.svg',
-          categories[4],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Clothing',
-          'https://image.flaticon.com/icons/svg/2794/2794012.svg',
-          categories[4],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Cosmetics',
-          'https://image.flaticon.com/icons/svg/545/545159.svg',
-          categories[4],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Coupons',
-          'https://image.flaticon.com/icons/svg/423/423809.svg',
-          categories[4],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Discount stores',
-          'https://image.flaticon.com/icons/svg/411/411807.svg',
-          categories[4],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Fragrances',
-          'https://image.flaticon.com/icons/svg/2611/2611095.svg',
-          categories[4],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Hairdressing',
-          'https://image.flaticon.com/icons/svg/393/393164.svg',
-          categories[4],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Handbags',
-          'https://image.flaticon.com/icons/svg/679/679997.svg',
-          categories[4],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Jewelry',
-          'https://image.flaticon.com/icons/svg/703/703280.svg',
-          categories[4],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Piercings',
-          'https://image.flaticon.com/icons/svg/1686/1686352.svg',
-          categories[4],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Shoes',
-          'https://image.flaticon.com/icons/svg/1940/1940912.svg',
-          categories[4],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Shopping malls',
-          'https://image.flaticon.com/icons/svg/1057/1057313.svg',
-          categories[4],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Spas',
-          'https://image.flaticon.com/icons/svg/2770/2770760.svg',
-          categories[4],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Sunglasses',
-          'https://image.flaticon.com/icons/svg/399/399745.svg',
-          categories[4],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Tattoos',
-          'https://image.flaticon.com/icons/svg/1686/1686442.svg',
-          categories[4],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Toys',
-          'https://image.flaticon.com/icons/svg/522/522043.svg',
-          categories[4],
-          seriesCallback
-        );
-      },
-
-      (seriesCallback) => {
-        createInterest(
-          'American football',
-          'https://image.flaticon.com/icons/svg/625/625369.svg',
-          categories[5],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Baseball',
-          'https://image.flaticon.com/icons/svg/484/484482.svg',
-          categories[5],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Basketball',
-          'https://image.flaticon.com/icons/svg/500/500245.svg',
-          categories[5],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Bowling',
-          'https://image.flaticon.com/icons/svg/2438/2438473.svg',
-          categories[5],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Boxing',
-          'https://image.flaticon.com/icons/svg/418/418171.svg',
-          categories[5],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Chess',
-          'https://image.flaticon.com/icons/svg/2633/2633894.svg',
-          categories[5],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Cycling',
-          'https://image.flaticon.com/icons/svg/2906/2906833.svg',
-          categories[5],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Esports',
-          'https://image.flaticon.com/icons/svg/2285/2285714.svg',
-          categories[5],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Fishing',
-          'https://image.flaticon.com/icons/svg/1830/1830797.svg',
-          categories[5],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Football',
-          'https://image.flaticon.com/icons/svg/2784/2784491.svg',
-          categories[5],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Golf',
-          'https://image.flaticon.com/icons/svg/491/491972.svg',
-          categories[5],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Martial arts',
-          'https://image.flaticon.com/icons/svg/625/625357.svg',
-          categories[5],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Ping pong',
-          'https://image.flaticon.com/icons/svg/866/866748.svg',
-          categories[5],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Poker',
-          'https://image.flaticon.com/icons/svg/867/867864.svg',
-          categories[5],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Racing',
-          'https://image.flaticon.com/icons/svg/469/469122.svg',
-          categories[5],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Running',
-          'https://image.flaticon.com/icons/svg/2460/2460093.svg',
-          categories[5],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Sailing',
-          'https://image.flaticon.com/icons/svg/434/434077.svg',
-          categories[5],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Skiing',
-          'https://image.flaticon.com/icons/svg/625/625360.svg',
-          categories[5],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Snowboarding',
-          'https://image.flaticon.com/icons/svg/2592/2592838.svg',
-          categories[5],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Speedcubing',
-          'https://image.flaticon.com/icons/svg/522/522052.svg',
-          categories[5],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Surfing',
-          'https://image.flaticon.com/icons/svg/2768/2768580.svg',
-          categories[5],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Swimming',
-          'https://image.flaticon.com/icons/svg/495/495821.svg',
-          categories[5],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Tennis',
-          'https://image.flaticon.com/icons/svg/802/802289.svg',
-          categories[5],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Volleyball',
-          'https://image.flaticon.com/icons/svg/2906/2906725.svg',
-          categories[5],
-          seriesCallback
-        );
-      },
-      (seriesCallback) => {
-        createInterest(
-          'Waterpolo',
-          'https://image.flaticon.com/icons/svg/495/495843.svg',
-          categories[5],
-          seriesCallback
-        );
-      },
-    ],
-    (error, results) => {
-      if (error) {
-        console.log(`Final error: ${error}`);
-      } else {
-        console.log(`Final results: ${results}`);
-      }
-
-      mongoose.connection.close();
-    }
+const createInterests = async (verbose) => {
+  console.log('Populating interests...');
+  displayLogs = verbose;
+  await createInterest(
+    'Art',
+    'https://image.flaticon.com/icons/svg/2811/2811172.svg',
+    categories[0]
   );
+
+  await createInterest(
+    'Ballet',
+    'https://image.flaticon.com/icons/png/512/1844/1844042.png',
+    categories[0]
+  );
+
+  await createInterest(
+    'Bars',
+    'https://image.flaticon.com/icons/svg/742/742096.svg',
+    categories[0]
+  );
+
+  await createInterest(
+    'Board games',
+    'https://image.flaticon.com/icons/png/512/2740/2740984.png',
+    categories[0]
+  );
+
+  await createInterest(
+    'Comics',
+    'https://image.flaticon.com/icons/svg/2628/2628930.svg',
+    categories[0]
+  );
+
+  await createInterest(
+    'Concerts',
+    'https://image.flaticon.com/icons/png/512/1789/1789786.png',
+    categories[0]
+  );
+
+  await createInterest(
+    'Festivals',
+    'https://image.flaticon.com/icons/png/512/2406/2406687.png',
+    categories[0]
+  );
+
+  await createInterest(
+    'Games',
+    'https://image.flaticon.com/icons/svg/744/744737.svg',
+    categories[0]
+  );
+
+  await createInterest(
+    'Literature',
+    'https://image.flaticon.com/icons/svg/2599/2599249.svg',
+    categories[0]
+  );
+
+  await createInterest(
+    'Magazines',
+    'https://image.flaticon.com/icons/svg/653/653014.svg',
+    categories[0]
+  );
+
+  await createInterest(
+    'Movies',
+    'https://image.flaticon.com/icons/svg/2824/2824516.svg',
+    categories[0]
+  );
+
+  await createInterest(
+    'Music',
+    'https://image.flaticon.com/icons/svg/651/651758.svg',
+    categories[0]
+  );
+
+  await createInterest(
+    'News',
+    'https://image.flaticon.com/icons/svg/1825/1825151.svg',
+    categories[0]
+  );
+
+  await createInterest(
+    'Night clubs',
+    'https://image.flaticon.com/icons/svg/1930/1930684.svg',
+    categories[0]
+  );
+
+  await createInterest(
+    'Reading',
+    'https://image.flaticon.com/icons/svg/2599/2599411.svg',
+    categories[0]
+  );
+
+  await createInterest(
+    'Series',
+    'https://image.flaticon.com/icons/svg/2881/2881114.svg',
+    categories[0]
+  );
+
+  await createInterest(
+    'Theatre',
+    'https://image.flaticon.com/icons/svg/2061/2061056.svg',
+    categories[0]
+  );
+
+
+  await createInterest(
+    'Bodybuilding',
+    'https://image.flaticon.com/icons/png/512/2307/2307905.png',
+    categories[1]
+  );
+
+  await createInterest(
+    'Fitness',
+    'https://image.flaticon.com/icons/svg/2307/2307959.svg',
+    categories[1]
+  );
+
+  await createInterest(
+    'Meditation',
+    'https://image.flaticon.com/icons/png/512/2781/2781698.png',
+    categories[1]
+  );
+
+  await createInterest(
+    'Weightlifting',
+    'https://image.flaticon.com/icons/svg/2307/2307879.svg',
+    categories[1]
+  );
+
+  await createInterest(
+    'Yoga',
+    'https://image.flaticon.com/icons/svg/2307/2307981.svg',
+    categories[1]
+  );
+
+
+  await createInterest(
+    'Acting',
+    'https://image.flaticon.com/icons/svg/2636/2636923.svg',
+    categories[2]
+  );
+
+  await createInterest(
+    'Automobiles',
+    'https://image.flaticon.com/icons/svg/500/500707.svg',
+    categories[2]
+  );
+
+  await createInterest(
+    'Charity',
+    'https://image.flaticon.com/icons/svg/838/838618.svg',
+    categories[2]
+  );
+
+  await createInterest(
+    'Chat',
+    'https://image.flaticon.com/icons/svg/509/509535.svg',
+    categories[2]
+  );
+
+  await createInterest(
+    'Cooking',
+    'https://image.flaticon.com/icons/svg/2863/2863411.svg',
+    categories[2]
+  );
+
+  await createInterest(
+    'Crafts',
+    'https://image.flaticon.com/icons/svg/2611/2611210.svg',
+    categories[2]
+  );
+
+  await createInterest(
+    'Dance',
+    'https://image.flaticon.com/icons/svg/498/498377.svg',
+    categories[2]
+  );
+
+  await createInterest(
+    'Furniture',
+    'https://image.flaticon.com/icons/svg/2610/2610836.svg',
+    categories[2]
+  );
+
+  await createInterest(
+    'Gardening',
+    'https://image.flaticon.com/icons/svg/2824/2824501.svg',
+    categories[2]
+  );
+
+  await createInterest(
+    'Motorcycles',
+    'https://image.flaticon.com/icons/svg/519/519598.svg',
+    categories[2]
+  );
+
+  await createInterest(
+    'Nature',
+    'https://image.flaticon.com/icons/svg/2899/2899987.svg',
+    categories[2]
+  );
+
+  await createInterest(
+    'Painting',
+    'https://image.flaticon.com/icons/svg/2736/2736499.svg',
+    categories[2]
+  );
+
+  await createInterest(
+    'Pets',
+    'https://image.flaticon.com/icons/svg/2064/2064863.svg',
+    categories[2]
+  );
+
+  await createInterest(
+    'Photography',
+    'https://image.flaticon.com/icons/svg/2636/2636410.svg',
+    categories[2]
+  );
+
+  await createInterest(
+    'Politics',
+    'https://image.flaticon.com/icons/svg/1672/1672268.svg',
+    categories[2]
+  );
+
+  await createInterest(
+    'Religion',
+    'https://image.flaticon.com/icons/svg/2242/2242222.svg',
+    categories[2]
+  );
+
+  await createInterest(
+    'Sculpture',
+    'https://image.flaticon.com/icons/png/512/2579/2579979.png',
+    categories[2]
+  );
+
+  await createInterest(
+    'Singing',
+    'https://image.flaticon.com/icons/svg/1974/1974848.svg',
+    categories[2]
+  );
+
+  await createInterest(
+    'Sustainability',
+    'https://image.flaticon.com/icons/svg/2371/2371903.svg',
+    categories[2]
+  );
+
+  await createInterest(
+    'Theme parks',
+    'https://image.flaticon.com/icons/png/512/2809/2809645.png',
+    categories[2]
+  );
+
+  await createInterest(
+    'Travel',
+    'https://image.flaticon.com/icons/svg/1175/1175017.svg',
+    categories[2]
+  );
+
+  await createInterest(
+    'Vacations',
+    'https://image.flaticon.com/icons/svg/1209/1209425.svg',
+    categories[2]
+  );
+
+  await createInterest(
+    'Volunteering',
+    'https://image.flaticon.com/icons/svg/2634/2634501.svg',
+    categories[2]
+  );
+
+  await createInterest(
+    'Writing',
+    'https://image.flaticon.com/icons/svg/1830/1830934.svg',
+    categories[2]
+  );
+
+
+  await createInterest(
+    'Advertising',
+    'https://image.flaticon.com/icons/svg/2787/2787828.svg',
+    categories[3]
+  );
+
+  await createInterest(
+    'Agriculture',
+    'https://image.flaticon.com/icons/svg/2708/2708842.svg',
+    categories[3]
+  );
+
+  await createInterest(
+    'Architecture',
+    'https://image.flaticon.com/icons/svg/2771/2771336.svg',
+    categories[3]
+  );
+
+  await createInterest(
+    'Aviation',
+    'https://image.flaticon.com/icons/svg/2302/2302811.svg',
+    categories[3]
+  );
+
+  await createInterest(
+    'Business',
+    'https://image.flaticon.com/icons/svg/1162/1162489.svg',
+    categories[3]
+  );
+
+  await createInterest(
+    'Construction',
+    'https://image.flaticon.com/icons/svg/819/819392.svg',
+    categories[3]
+  );
+
+  await createInterest(
+    'Design',
+    'https://image.flaticon.com/icons/svg/802/802033.svg',
+    categories[3]
+  );
+
+  await createInterest(
+    'Economics',
+    'https://image.flaticon.com/icons/svg/2179/2179261.svg',
+    categories[3]
+  );
+
+  await createInterest(
+    'Education',
+    'https://image.flaticon.com/icons/svg/2681/2681857.svg',
+    categories[3]
+  );
+
+  await createInterest(
+    'Engineering',
+    'https://image.flaticon.com/icons/svg/897/897168.svg',
+    categories[3]
+  );
+
+  await createInterest(
+    'Entrepreneurship',
+    'https://image.flaticon.com/icons/svg/1535/1535019.svg',
+    categories[3]
+  );
+
+  await createInterest(
+    'Health care',
+    'https://image.flaticon.com/icons/svg/1021/1021606.svg',
+    categories[3]
+  );
+
+  await createInterest(
+    'Insurance',
+    'https://image.flaticon.com/icons/svg/2754/2754975.svg',
+    categories[3]
+  );
+
+  await createInterest(
+    'Investment',
+    'https://image.flaticon.com/icons/svg/2474/2474455.svg',
+    categories[3]
+  );
+
+  await createInterest(
+    'Law',
+    'https://image.flaticon.com/icons/svg/1208/1208198.svg',
+    categories[3]
+  );
+
+  await createInterest(
+    'Management',
+    'https://image.flaticon.com/icons/svg/1208/1208203.svg',
+    categories[3]
+  );
+
+  await createInterest(
+    'Marketing',
+    'https://image.flaticon.com/icons/svg/1378/1378593.svg',
+    categories[3]
+  );
+
+  await createInterest(
+    'Real estate',
+    'https://image.flaticon.com/icons/svg/602/602175.svg',
+    categories[3]
+  );
+
+  await createInterest(
+    'Retail',
+    'https://image.flaticon.com/icons/svg/1198/1198361.svg',
+    categories[3]
+  );
+
+  await createInterest(
+    'Sales',
+    'https://image.flaticon.com/icons/svg/1312/1312187.svg',
+    categories[3]
+  );
+
+  await createInterest(
+    'Science',
+    'https://image.flaticon.com/icons/svg/2784/2784451.svg',
+    categories[3]
+  );
+
+  await createInterest(
+    'Social media',
+    'https://image.flaticon.com/icons/svg/2065/2065203.svg',
+    categories[3]
+  );
+
+  await createInterest(
+    'Software',
+    'https://image.flaticon.com/icons/svg/1149/1149168.svg',
+    categories[3]
+  );
+
+
+  await createInterest(
+    'Beauty salons',
+    'https://image.flaticon.com/icons/svg/1940/1940922.svg',
+    categories[4]
+  );
+
+  await createInterest(
+    'Boutiques',
+    'https://image.flaticon.com/icons/svg/1719/1719625.svg',
+    categories[4]
+  );
+
+  await createInterest(
+    'Clothing',
+    'https://image.flaticon.com/icons/svg/2794/2794012.svg',
+    categories[4]
+  );
+
+  await createInterest(
+    'Cosmetics',
+    'https://image.flaticon.com/icons/svg/545/545159.svg',
+    categories[4]
+  );
+
+  await createInterest(
+    'Coupons',
+    'https://image.flaticon.com/icons/svg/423/423809.svg',
+    categories[4]
+  );
+
+  await createInterest(
+    'Discount stores',
+    'https://image.flaticon.com/icons/svg/411/411807.svg',
+    categories[4]
+  );
+
+  await createInterest(
+    'Fragrances',
+    'https://image.flaticon.com/icons/svg/2611/2611095.svg',
+    categories[4]
+  );
+
+  await createInterest(
+    'Hairdressing',
+    'https://image.flaticon.com/icons/svg/393/393164.svg',
+    categories[4]
+  );
+
+  await createInterest(
+    'Handbags',
+    'https://image.flaticon.com/icons/svg/679/679997.svg',
+    categories[4]
+  );
+
+  await createInterest(
+    'Jewelry',
+    'https://image.flaticon.com/icons/svg/703/703280.svg',
+    categories[4]
+  );
+
+  await createInterest(
+    'Piercings',
+    'https://image.flaticon.com/icons/svg/1686/1686352.svg',
+    categories[4]
+  );
+
+  await createInterest(
+    'Shoes',
+    'https://image.flaticon.com/icons/svg/1940/1940912.svg',
+    categories[4]
+  );
+
+  await createInterest(
+    'Shopping malls',
+    'https://image.flaticon.com/icons/svg/1057/1057313.svg',
+    categories[4]
+  );
+
+  await createInterest(
+    'Spas',
+    'https://image.flaticon.com/icons/svg/2770/2770760.svg',
+    categories[4]
+  );
+
+  await createInterest(
+    'Sunglasses',
+    'https://image.flaticon.com/icons/svg/399/399745.svg',
+    categories[4]
+  );
+
+  await createInterest(
+    'Tattoos',
+    'https://image.flaticon.com/icons/svg/1686/1686442.svg',
+    categories[4]
+  );
+
+  await createInterest(
+    'Toys',
+    'https://image.flaticon.com/icons/svg/522/522043.svg',
+    categories[4]
+  );
+
+
+  await createInterest(
+    'American football',
+    'https://image.flaticon.com/icons/svg/625/625369.svg',
+    categories[5]
+  );
+
+  await createInterest(
+    'Baseball',
+    'https://image.flaticon.com/icons/svg/484/484482.svg',
+    categories[5]
+  );
+
+  await createInterest(
+    'Basketball',
+    'https://image.flaticon.com/icons/svg/500/500245.svg',
+    categories[5]
+  );
+
+  await createInterest(
+    'Bowling',
+    'https://image.flaticon.com/icons/svg/2438/2438473.svg',
+    categories[5]
+  );
+
+  await createInterest(
+    'Boxing',
+    'https://image.flaticon.com/icons/svg/418/418171.svg',
+    categories[5]
+  );
+
+  await createInterest(
+    'Chess',
+    'https://image.flaticon.com/icons/svg/2633/2633894.svg',
+    categories[5]
+  );
+
+  await createInterest(
+    'Cycling',
+    'https://image.flaticon.com/icons/svg/2906/2906833.svg',
+    categories[5]
+  );
+
+  await createInterest(
+    'Esports',
+    'https://image.flaticon.com/icons/svg/2285/2285714.svg',
+    categories[5]
+  );
+
+  await createInterest(
+    'Fishing',
+    'https://image.flaticon.com/icons/svg/1830/1830797.svg',
+    categories[5]
+  );
+
+  await createInterest(
+    'Football',
+    'https://image.flaticon.com/icons/svg/2784/2784491.svg',
+    categories[5]
+  );
+
+  await createInterest(
+    'Golf',
+    'https://image.flaticon.com/icons/svg/491/491972.svg',
+    categories[5]
+  );
+
+  await createInterest(
+    'Martial arts',
+    'https://image.flaticon.com/icons/svg/625/625357.svg',
+    categories[5]
+  );
+
+  await createInterest(
+    'Ping pong',
+    'https://image.flaticon.com/icons/svg/866/866748.svg',
+    categories[5]
+  );
+
+  await createInterest(
+    'Poker',
+    'https://image.flaticon.com/icons/svg/867/867864.svg',
+    categories[5]
+  );
+
+  await createInterest(
+    'Racing',
+    'https://image.flaticon.com/icons/svg/469/469122.svg',
+    categories[5]
+  );
+
+  await createInterest(
+    'Running',
+    'https://image.flaticon.com/icons/svg/2460/2460093.svg',
+    categories[5]
+  );
+
+  await createInterest(
+    'Sailing',
+    'https://image.flaticon.com/icons/svg/434/434077.svg',
+    categories[5]
+  );
+
+  await createInterest(
+    'Skiing',
+    'https://image.flaticon.com/icons/svg/625/625360.svg',
+    categories[5]
+  );
+
+  await createInterest(
+    'Snowboarding',
+    'https://image.flaticon.com/icons/svg/2592/2592838.svg',
+    categories[5]
+  );
+
+  await createInterest(
+    'Speedcubing',
+    'https://image.flaticon.com/icons/svg/522/522052.svg',
+    categories[5]
+  );
+
+  await createInterest(
+    'Surfing',
+    'https://image.flaticon.com/icons/svg/2768/2768580.svg',
+    categories[5]
+  );
+
+  await createInterest(
+    'Swimming',
+    'https://image.flaticon.com/icons/svg/495/495821.svg',
+    categories[5]
+  );
+
+  await createInterest(
+    'Tennis',
+    'https://image.flaticon.com/icons/svg/802/802289.svg',
+    categories[5]
+  );
+
+  await createInterest(
+    'Volleyball',
+    'https://image.flaticon.com/icons/svg/2906/2906725.svg',
+    categories[5]
+  );
+
+  await createInterest(
+    'Waterpolo',
+    'https://image.flaticon.com/icons/svg/495/495843.svg',
+    categories[5]
+  );
+
+  console.log(`Interests created: ${interests.length}`)
 };
 
-createInterests();
+module.exports = {createInterests}

--- a/api/db/populate-interests.js
+++ b/api/db/populate-interests.js
@@ -692,7 +692,7 @@ const createInterests = async (verbose) => {
     categories[5]
   );
 
-  console.log(`Interests created: ${interests.length}`)
+  console.log(`Interests created: ${interests.length}`);
 };
 
 module.exports = {createInterests}

--- a/api/db/populate-interests.js
+++ b/api/db/populate-interests.js
@@ -1,3 +1,5 @@
+const prompts = require('prompts');
+
 const Interest = require('../models/Interest');
 
 const categories = [
@@ -22,7 +24,16 @@ const createInterests = async (verbose) => {
   console.log('\x1b[0m', 'Populating interests...');
   displayLogs = verbose;
 
-  if ((await Interest.countDocuments()) !== 0) await Interest.collection.drop();
+  if ((await Interest.countDocuments()) !== 0) {
+    const answer = await prompts({
+      type: 'confirm',
+      name: 'value',
+      message:
+        'The interests collection already contains some documents. It is recommended that you drop the existing collection before proceeding to avoid duplication. Would you like to drop the existing collection before proceeding?',
+      initial: true,
+    });
+    if (answer.value) await Interest.collection.drop();
+  }
 
   await createInterest(
     'Art',

--- a/api/db/populate-interests.js
+++ b/api/db/populate-interests.js
@@ -21,6 +21,9 @@ const createInterest = async (name, avatar, category) => {
 const createInterests = async (verbose) => {
   console.log('Populating interests...');
   displayLogs = verbose;
+
+  if ((await Interest.countDocuments()) !== 0) await Interest.collection.drop();
+
   await createInterest(
     'Art',
     'https://image.flaticon.com/icons/svg/2811/2811172.svg',
@@ -123,7 +126,6 @@ const createInterests = async (verbose) => {
     categories[0]
   );
 
-
   await createInterest(
     'Bodybuilding',
     'https://image.flaticon.com/icons/png/512/2307/2307905.png',
@@ -153,7 +155,6 @@ const createInterests = async (verbose) => {
     'https://image.flaticon.com/icons/svg/2307/2307981.svg',
     categories[1]
   );
-
 
   await createInterest(
     'Acting',
@@ -299,7 +300,6 @@ const createInterests = async (verbose) => {
     categories[2]
   );
 
-
   await createInterest(
     'Advertising',
     'https://image.flaticon.com/icons/svg/2787/2787828.svg',
@@ -438,7 +438,6 @@ const createInterests = async (verbose) => {
     categories[3]
   );
 
-
   await createInterest(
     'Beauty salons',
     'https://image.flaticon.com/icons/svg/1940/1940922.svg',
@@ -540,7 +539,6 @@ const createInterests = async (verbose) => {
     'https://image.flaticon.com/icons/svg/522/522043.svg',
     categories[4]
   );
-
 
   await createInterest(
     'American football',
@@ -695,4 +693,4 @@ const createInterests = async (verbose) => {
   console.log(`Interests created: ${interests.length}`);
 };
 
-module.exports = {createInterests}
+module.exports = { createInterests };

--- a/api/db/populate-users.js
+++ b/api/db/populate-users.js
@@ -1,3 +1,5 @@
+const prompts = require('prompts');
+
 const User = require('../models/User');
 const Interest = require('../models/Interest');
 
@@ -28,7 +30,7 @@ const createUser = async (userParams) => {
 const getRandomDate = (startDate, endDate) =>
   new Date(+startDate + Math.random() * (endDate - startDate));
 
-const createAdminUser = () => () => {
+const createAdminUser = () => {
   createUser({
     name: 'Admin',
     email: `admin@tisn.app`,
@@ -50,7 +52,20 @@ const createUsers = async (verbose, admin, randomCountry, numberOfRecords) => {
   const now = new Date();
   const usersArray = [];
 
-  if (admin) usersArray.push(createAdminUser());
+  if (interestsList.length === 0) {
+    const answer = await prompts({
+      type: 'confirm',
+      name: 'value',
+      message:
+        'The interests collection does not exist. Users created will not have any interests. Do you wish to continue?',
+      initial: true,
+    });
+    if (!answer.value) return;
+  }
+
+  if (admin && !(await User.exists({ email: 'admin@tisn.app' }))) {
+    usersArray.push(createAdminUser());
+  }
 
   for (let i = 0; i < numberOfRecords; i++) {
     const name = uniqueNamesGenerator({

--- a/api/db/populate-users.js
+++ b/api/db/populate-users.js
@@ -43,7 +43,7 @@ const createAdminUser = () => () => {
   });
 };
 
-const createUsers = async (verbose, admin, numberOfRecords) => {
+const createUsers = async (verbose, admin, randomCountry, numberOfRecords) => {
   displayLogs = verbose;
   console.log('\x1b[0m', 'Populating users...');
   let interestsList = await Interest.distinct('_id');
@@ -57,9 +57,12 @@ const createUsers = async (verbose, admin, numberOfRecords) => {
       dictionaries: [names, names],
       separator: ' ',
     });
-    const country = countries[Math.floor(Math.random() * countries.length)];
-    const region =
-      country.regions[Math.floor(Math.random() * country.regions.length)];
+    const country = randomCountry
+      ? countries[Math.floor(Math.random() * countries.length)]
+      : { countryShortCode: 'ES' };
+    const region = randomCountry
+      ? country.regions[Math.floor(Math.random() * country.regions.length)]
+      : { shortCode: 'AN' };
 
     const userParams = {
       name,
@@ -86,7 +89,7 @@ const createUsers = async (verbose, admin, numberOfRecords) => {
     console.log(
       '\x1b[32m',
       `
-      Admin user created: 
+      Admin user created:
       \tName: Admin
       \tEmail: admin@tisn.app
     `

--- a/api/db/populate-users.js
+++ b/api/db/populate-users.js
@@ -48,7 +48,7 @@ const createAdminUser = () => () => {
 
 const createUsers = async (verbose, admin, numberOfRecords) => {
   displayLogs = verbose;
-  console.log('Populating users...')
+  console.log('Populating users...');
   let interestsList = await Interest.distinct('_id');
   const now = new Date();
   const usersArray = [];

--- a/api/db/populate-users.js
+++ b/api/db/populate-users.js
@@ -29,26 +29,23 @@ const getRandomDate = (startDate, endDate) =>
   new Date(+startDate + Math.random() * (endDate - startDate));
 
 const createAdminUser = () => () => {
-  createUser(
-    {
-      name: 'Admin',
-      email: `admin@tisn.app`,
-      emailConfirmed: true,
-      emailConfirmedAt: new Date(),
-      country: 'US',
-      region: 'FL',
-      preferredLocale: 'en',
-      dateOfBirth: new Date(2000, 01, 01),
-      interests: [],
-      admin: true,
-    }
-  );
+  createUser({
+    name: 'Admin',
+    email: `admin@tisn.app`,
+    emailConfirmed: true,
+    emailConfirmedAt: new Date(),
+    country: 'US',
+    region: 'FL',
+    preferredLocale: 'en',
+    dateOfBirth: new Date(2000, 01, 01),
+    interests: [],
+    admin: true,
+  });
 };
-
 
 const createUsers = async (verbose, admin, numberOfRecords) => {
   displayLogs = verbose;
-  console.log('Populating users...');
+  console.log('\x1b[0m', 'Populating users...');
   let interestsList = await Interest.distinct('_id');
   const now = new Date();
   const usersArray = [];
@@ -82,13 +79,21 @@ const createUsers = async (verbose, admin, numberOfRecords) => {
       admin: false,
     };
 
-    usersArray.push(
-      await createUser(userParams)
-    );
+    usersArray.push(await createUser(userParams));
   }
 
-  console.log(`Users created: ${usersArray.length}`);
+  if (admin) {
+    console.log(
+      '\x1b[32m',
+      `
+      Admin user created: 
+      \tName: Admin
+      \tEmail: admin@tisn.app
+    `
+    );
+  }
+  console.log('\x1b[32m', `Users created: ${usersArray.length}`);
   return usersArray;
 };
 
-module.exports = {createUsers}
+module.exports = { createUsers };

--- a/api/db/populate.js
+++ b/api/db/populate.js
@@ -43,7 +43,6 @@ const populateSpecifiedTable = async () => {
       closeMongoDb();
       break;
     case 'interests':
-      console.log('Interests table will be populated');
       connectMongoDb();
       await createInterests(userArgs.v);
       closeMongoDb();

--- a/api/db/populate.js
+++ b/api/db/populate.js
@@ -5,24 +5,40 @@ Options:
 1. Populate all db's
 2. Populate individual db's
 3. Talked about implementing log flags (verbose, pertinent)
+4. Number of record's flag
+  * Users
+  * Events
 */
 
 const minimist = require('minimist');
+const { connectMongoDb, closeMongoDb } = require('./db-connection');
+const { createUsers } = require('./populate-users');
+
 
 const userArgs = minimist(process.argv.slice(2), {
-  string: ['table'],
-  boolean: ['verbose'],
-  alias: [{v: 'verbose'}, {t: 'table'}]
+  string: ['table', 'number'],
+  boolean: ['verbose', 'admin'],
+  default: {number: '100'},
+  alias: [
+    {a: 'admin'},
+    {t: 'table'},
+    {v: 'verbose'},
+  ]
 });
 
-const populateAllTables = () => {
-  console.log('All tables will be populated');
+const populateAllTables = async () => {
+  console.log('Populating all tables');
+  connectMongoDb();
+  await createUsers(userArgs.v, userArgs.a, userArgs.number);
+  closeMongoDb();
 };
 
-const populateSpecifiedTable = () => {
+const populateSpecifiedTable = async () => {
   switch (userArgs.t.toLowerCase()) {
     case 'users':
-      console.log('Users table will be populated');
+      connectMongoDb();
+      await createUsers(userArgs.v, userArgs.a, userArgs.number);
+      closeMongoDb();
       break;
     case 'interests':
       console.log('Interests table will be populated');

--- a/api/db/populate.js
+++ b/api/db/populate.js
@@ -19,24 +19,19 @@ const userArgs = minimist(process.argv.slice(2), {
   string: ['collection', 'number'],
   boolean: ['verbose', 'admin', 'random-country'],
   default: { number: '100' },
-  alias: [
-    { a: 'admin' },
-    { c: 'collection' },
-    { rc: 'random' },
-    { v: 'verbose' },
-  ],
+  alias: { a: 'admin', c: 'collection', r: 'random-country', v: 'verbose' },
 });
 
 const populateAllTables = async () => {
   console.log('Populating all tables');
   connectMongoDb();
   await createInterests(userArgs.v);
-  await createUsers(userArgs.v, userArgs.a, userArgs.rc, userArgs.number);
+  await createUsers(userArgs.v, userArgs.a, userArgs.r, userArgs.number);
   closeMongoDb();
 };
 
 const populateSpecifiedTable = async () => {
-  switch (userArgs.t.toLowerCase()) {
+  switch (userArgs.c.toLowerCase()) {
     case 'users':
       connectMongoDb();
       await createUsers(userArgs.v, userArgs.a, userArgs.rc, userArgs.number);
@@ -54,4 +49,4 @@ const populateSpecifiedTable = async () => {
 };
 
 console.log(userArgs);
-userArgs.t ? populateSpecifiedTable() : populateAllTables();
+userArgs.c ? populateSpecifiedTable() : populateAllTables();

--- a/api/db/populate.js
+++ b/api/db/populate.js
@@ -1,0 +1,37 @@
+#! /usr/bin/env node
+
+/*
+Options:
+1. Populate all db's
+2. Populate individual db's
+3. Talked about implementing log flags (verbose, pertinent)
+*/
+
+const minimist = require('minimist');
+
+const userArgs = minimist(process.argv.slice(2), {
+  string: ['table'],
+  boolean: ['verbose'],
+  alias: [{v: 'verbose'}, {t: 'table'}]
+});
+
+const populateAllTables = () => {
+  console.log('All tables will be populated');
+};
+
+const populateSpecifiedTable = () => {
+  switch (userArgs.t.toLowerCase()) {
+    case 'users':
+      console.log('Users table will be populated');
+      break;
+    case 'interests':
+      console.log('Interests table will be populated');
+      break;
+    default:
+      console.log('Table or script does not exist');
+      break;
+  };
+};
+
+console.log(userArgs);
+userArgs.t ? populateSpecifiedTable() : populateAllTables();

--- a/api/db/populate.js
+++ b/api/db/populate.js
@@ -15,16 +15,11 @@ const { connectMongoDb, closeMongoDb } = require('./db-connection');
 const { createInterests } = require('./populate-interests');
 const { createUsers } = require('./populate-users');
 
-
 const userArgs = minimist(process.argv.slice(2), {
-  string: ['table', 'number'],
+  string: ['collection', 'number'],
   boolean: ['verbose', 'admin'],
-  default: {number: '100'},
-  alias: [
-    {a: 'admin'},
-    {t: 'table'},
-    {v: 'verbose'},
-  ]
+  default: { number: '100' },
+  alias: [{ a: 'admin' }, { c: 'collection' }, { v: 'verbose' }],
 });
 
 const populateAllTables = async () => {
@@ -50,7 +45,7 @@ const populateSpecifiedTable = async () => {
     default:
       console.log('Table or script does not exist');
       break;
-  };
+  }
 };
 
 console.log(userArgs);

--- a/api/db/populate.js
+++ b/api/db/populate.js
@@ -17,16 +17,21 @@ const { createUsers } = require('./populate-users');
 
 const userArgs = minimist(process.argv.slice(2), {
   string: ['collection', 'number'],
-  boolean: ['verbose', 'admin'],
+  boolean: ['verbose', 'admin', 'random-country'],
   default: { number: '100' },
-  alias: [{ a: 'admin' }, { c: 'collection' }, { v: 'verbose' }],
+  alias: [
+    { a: 'admin' },
+    { c: 'collection' },
+    { rc: 'random' },
+    { v: 'verbose' },
+  ],
 });
 
 const populateAllTables = async () => {
   console.log('Populating all tables');
   connectMongoDb();
   await createInterests(userArgs.v);
-  await createUsers(userArgs.v, userArgs.a, userArgs.number);
+  await createUsers(userArgs.v, userArgs.a, userArgs.rc, userArgs.number);
   closeMongoDb();
 };
 
@@ -34,7 +39,7 @@ const populateSpecifiedTable = async () => {
   switch (userArgs.t.toLowerCase()) {
     case 'users':
       connectMongoDb();
-      await createUsers(userArgs.v, userArgs.a, userArgs.number);
+      await createUsers(userArgs.v, userArgs.a, userArgs.rc, userArgs.number);
       closeMongoDb();
       break;
     case 'interests':

--- a/api/db/populate.js
+++ b/api/db/populate.js
@@ -12,6 +12,7 @@ Options:
 
 const minimist = require('minimist');
 const { connectMongoDb, closeMongoDb } = require('./db-connection');
+const { createInterests } = require('./populate-interests');
 const { createUsers } = require('./populate-users');
 
 
@@ -29,6 +30,7 @@ const userArgs = minimist(process.argv.slice(2), {
 const populateAllTables = async () => {
   console.log('Populating all tables');
   connectMongoDb();
+  await createInterests(userArgs.v);
   await createUsers(userArgs.v, userArgs.a, userArgs.number);
   closeMongoDb();
 };
@@ -42,6 +44,9 @@ const populateSpecifiedTable = async () => {
       break;
     case 'interests':
       console.log('Interests table will be populated');
+      connectMongoDb();
+      await createInterests(userArgs.v);
+      closeMongoDb();
       break;
     default:
       console.log('Table or script does not exist');

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1528,6 +1528,12 @@
         "json-buffer": "3.0.0"
       }
     },
+    "kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "dev": true
+    },
     "latest-version": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-5.1.0.tgz",
@@ -2214,6 +2220,16 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
+    "prompts": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.3.2.tgz",
+      "integrity": "sha512-Q06uKs2CkNYVID0VqwfAl9mipo99zkBv/n2JtWY89Yxa3ZabWSrs0e2KTudKVa3peLUvYXMefDqIleLPVUBZMA==",
+      "dev": true,
+      "requires": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.4"
+      }
+    },
     "proxy-addr": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
@@ -2565,6 +2581,12 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+      "dev": true
+    },
+    "sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "dev": true
     },
     "slash": {

--- a/api/package.json
+++ b/api/package.json
@@ -13,7 +13,8 @@
   "scripts": {
     "start": "nodemon ./bin/www",
     "start:prod": "node ./bin/www",
-    "db:populate": "node ./db/populate.js"
+    "db:populate": "node ./db/populate.js",
+    "db:drop": "node ./db/drop.js"
   },
   "dependencies": {
     "@sendgrid/mail": "^7.2.6",

--- a/api/package.json
+++ b/api/package.json
@@ -12,7 +12,8 @@
   "license": "AGPL-3.0-or-later",
   "scripts": {
     "start": "nodemon ./bin/www",
-    "start:prod": "node ./bin/www"
+    "start:prod": "node ./bin/www",
+    "db:populate": "node ./db/populate.js"
   },
   "dependencies": {
     "@sendgrid/mail": "^7.2.6",
@@ -42,10 +43,11 @@
   "devDependencies": {
     "husky": "^4.3.0",
     "lint-staged": "^10.4.0",
+    "minimist": "^1.2.5",
     "nodemon": "^2.0.4",
     "prettier": "2.1.2",
-    "unique-names-generator": "^4.3.1",
-    "prompts": "^2.3.2"
+    "prompts": "^2.3.2",
+    "unique-names-generator": "^4.3.1"
   },
   "husky": {
     "hooks": {

--- a/api/package.json
+++ b/api/package.json
@@ -44,7 +44,8 @@
     "lint-staged": "^10.4.0",
     "nodemon": "^2.0.4",
     "prettier": "2.1.2",
-    "unique-names-generator": "^4.3.1"
+    "unique-names-generator": "^4.3.1",
+    "prompts": "^2.3.2"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Fixes #314.

This is still a work in progress, however I wanted you to be able to see the progress I have made and give you an opportunity to make any suggestions or corrections. 

Also, if the user runs the command to populate all tables, should we delete and replace the Interests table if it already exists? If we don't, then the interests table would contain duplicates.

The new command for populating all the databases would be:
`node db/populate`

To populate a specific table:
`node db/populate -t <table-name>` or `node db/populate --table <table-name>`

Other flags:
`-v` or `--verbose` to display all logs.
`--number` to specify the number of records to create. (Default: 100; currently only used for the users table)

I'll update the readme with the similar information before we merge this.