### PR TITLE
Add script to populate (and drop) the events collection

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -13,8 +13,8 @@ There's a script that can be used to populate all the collections with dummy dat
 The following arguments can be passed to the script:
 
 - `-c` or `--collection`, specify the collection you want to populate.
-- `-m` or `--multiplier`, multiply the default number of users generated (100).
-- `-r` or `--random-location`, randomizes the country and region each user is located in. By default, all users are located in Madrid, Spain.
+- `-m` or `--multiplier`, multiply the default number of users (100) and events (500) generated.
+- `-r` or `--random-location`, randomizes the country and region each user and event is located in. By default, all users and events are located in Madrid, Spain.
 - `-v` or `--verbose`, logs each generated document to the console.
 
 When the users collection is first populated, an admin user with the following information is also generated:

--- a/api/db/drop.js
+++ b/api/db/drop.js
@@ -5,6 +5,7 @@ const { connectDb, closeDb } = require('./connection');
 
 const Interest = require('../models/Interest');
 const User = require('../models/User');
+const Event = require('../models/Event');
 
 const userArgs = minimist(process.argv.slice(2), {
   string: 'collection',
@@ -33,10 +34,21 @@ const dropUsers = async () => {
   }
 };
 
+const dropEvents = async () => {
+  console.log('\n', '\x1b[0m', 'Dropping events collection...');
+  if ((await Event.countDocuments()) !== 0) {
+    await Event.collection.drop();
+    console.log('\x1b[31m', 'Dropped events collection');
+  } else {
+    console.log('\x1b[33m', 'events collection is already empty');
+  }
+};
+
 const dropCollections = async () => {
   connectDb();
   await dropInterests();
   await dropUsers();
+  await dropEvents();
   closeDb();
 };
 
@@ -49,9 +61,12 @@ const dropCollection = async () => {
     case 'users':
       await dropUsers();
       break;
+    case 'events':
+      await dropEvents();
+      break;
     default:
       console.log(
-        `Unknown collection '${userArgs.c}', possible options are: [interests, users]`
+        `Unknown collection '${userArgs.c}', possible options are: [interests, users, events]`
       );
       break;
   }

--- a/api/db/drop.js
+++ b/api/db/drop.js
@@ -23,22 +23,14 @@ const userArgs = minimist(process.argv.slice(2), {
 
 const dropInterests = async () => {
   console.log('\n', '\x1b[0m', 'Dropping interests collection...');
-  if (await getInterestsCount() !== 0) {
+  if ((await getInterestsCount()) !== 0) {
     await Interest.collection.drop();
     console.log('\x1b[31m', 'Dropped interests collection');
   } else {
     console.log('\x1b[33m', 'Interests collection is already empty');
   }
 
-  if (await getEventsCount() !== 0) {
-    const drop = await createPrompt(
-      'The events collection is dependent on the interests collection. Drop events collection?'
-    );
-
-    if (drop) await dropEvents(drop);
-  }
-
-  if (await getUsersCount() !== 0) {
+  if ((await getUsersCount()) !== 0) {
     const drop = await createPrompt(
       'The users collection is dependent on the users collection. Drop users collection?'
     );
@@ -49,7 +41,7 @@ const dropInterests = async () => {
 
 const dropUsers = async (confirmed = false) => {
   console.log('\n', '\x1b[0m', 'Dropping users collection...');
-  if (confirmed || await getUsersCount() !== 0) {
+  if (confirmed || (await getUsersCount()) !== 0) {
     await User.collection.drop();
     console.log('\x1b[31m', 'Dropped users collection');
   } else {
@@ -57,10 +49,10 @@ const dropUsers = async (confirmed = false) => {
     return;
   }
 
-  if (await getEventsCount() !== 0) {
+  if ((await getEventsCount()) !== 0) {
     const drop = await createPrompt(
       'The events collection is dependent on the users collection. Drop events collection?'
-    )
+    );
 
     if (drop) await dropEvents(drop);
   }
@@ -68,7 +60,7 @@ const dropUsers = async (confirmed = false) => {
 
 const dropEvents = async (confirmed = false) => {
   console.log('\n', '\x1b[0m', 'Dropping events collection...');
-  if (confirmed || await getEventsCount() !== 0) {
+  if (confirmed || (await getEventsCount()) !== 0) {
     await Event.collection.drop();
     console.log('\x1b[31m', 'Dropped events collection');
   } else {
@@ -76,7 +68,7 @@ const dropEvents = async (confirmed = false) => {
     return;
   }
 
-  if (await getAttendantsCount() !== 0) {
+  if ((await getAttendantsCount()) !== 0) {
     const drop = await createPrompt(
       'The attendants collection is dependent on the events collection. Drop attendants collection?'
     );
@@ -87,13 +79,13 @@ const dropEvents = async (confirmed = false) => {
 
 const dropAttendants = async (confirmed = false) => {
   console.log('\n', '\x1b[0m', 'Dropping attendants collection...');
-  if (confirmed || await getAttendantsCount() !== 0) {
+  if (confirmed || (await getAttendantsCount()) !== 0) {
     await Attendant.collection.drop();
     console.log('\x1b[31m', 'Dropped attendants collection');
   } else {
     console.log('\x1b[33m', 'Attendants collection is already empty');
   }
-}
+};
 
 const dropCollections = async () => {
   connectDb();

--- a/api/db/drop.js
+++ b/api/db/drop.js
@@ -7,6 +7,12 @@ const Interest = require('../models/Interest');
 const User = require('../models/User');
 const Event = require('../models/Event');
 const Attendant = require('../models/Attendant');
+const { createPrompt } = require('./utils');
+
+const interestCount = async () => await Interest.countDocuments();
+const userCount = async () => await User.countDocuments();
+const eventCount = async () => await Event.countDocuments();
+const attendantCount = async () => await Attendant.countDocuments();
 
 const userArgs = minimist(process.argv.slice(2), {
   string: 'collection',
@@ -17,7 +23,7 @@ const userArgs = minimist(process.argv.slice(2), {
 
 const dropInterests = async () => {
   console.log('\n', '\x1b[0m', 'Dropping interests collection...');
-  if ((await Interest.countDocuments()) !== 0) {
+  if (await interestCount() !== 0) {
     await Interest.collection.drop();
     console.log('\x1b[31m', 'Dropped interests collection');
   } else {
@@ -27,36 +33,58 @@ const dropInterests = async () => {
 
 const dropUsers = async () => {
   console.log('\n', '\x1b[0m', 'Dropping users collection...');
-  if ((await User.countDocuments()) !== 0) {
+  if (await userCount() !== 0) {
     await User.collection.drop();
     console.log('\x1b[31m', 'Dropped users collection');
   } else {
     console.log('\x1b[33m', 'Users collection is already empty');
+    return;
+  }
+
+  if (await eventCount() !== 0) {
+    const drop = await createPrompt(
+      'The events collection is dependent on the events collection. Drop events collection?'
+    )
+
+    if (drop) await dropEvents(drop);
   }
 };
 
-const dropEvents = async () => {
-  console.log('\n', '\x1b[0m', 'Dropping events and attendants collection...');
-  if ((await Event.countDocuments()) !== 0) {
+const dropEvents = async (confirmed = false) => {
+  console.log('\n', '\x1b[0m', 'Dropping events collection...');
+  if (confirmed || await eventCount() !== 0) {
     await Event.collection.drop();
     console.log('\x1b[31m', 'Dropped events collection');
   } else {
-    console.log('\x1b[33m', 'events collection is already empty');
+    console.log('\x1b[33m', 'Events collection is already empty');
+    return;
   }
 
-  if ((await Attendant.countDocuments()) !== 0) {
-    await Attendant.collection.drop();
-    console.log('\x1b[31m', 'Dropped attendants collection');
-  } else {
-    console.log('\x1b[33m', 'attendants collection is already empty');
+  if (await attendantCount() !== 0) {
+    const drop = await createPrompt(
+      'The attendants collection is dependent on the events collection. Drop attendants collection?'
+    );
+
+    if (drop) await dropAttendants(drop);
   }
 };
 
+const dropAttendants = async (confirmed = false) => {
+  console.log('\n', '\x1b[0m', 'Dropping attendants collection...');
+  if (confirmed || await attendantCount() !== 0) {
+    await Attendant.collection.drop();
+    console.log('\x1b[31m', 'Dropped attendants collection');
+  } else {
+    console.log('\x1b[33m', 'Attendants collection is already empty');
+  }
+}
+
 const dropCollections = async () => {
   connectDb();
-  await dropInterests();
-  await dropUsers();
+  await dropAttendants();
   await dropEvents();
+  await dropUsers();
+  await dropInterests();
   closeDb();
 };
 
@@ -71,6 +99,9 @@ const dropCollection = async () => {
       break;
     case 'events':
       await dropEvents();
+      break;
+    case 'attendants':
+      await dropAttendants();
       break;
     default:
       console.log(

--- a/api/db/drop.js
+++ b/api/db/drop.js
@@ -6,6 +6,7 @@ const { connectDb, closeDb } = require('./connection');
 const Interest = require('../models/Interest');
 const User = require('../models/User');
 const Event = require('../models/Event');
+const Attendant = require('../models/Attendant');
 
 const userArgs = minimist(process.argv.slice(2), {
   string: 'collection',
@@ -35,12 +36,19 @@ const dropUsers = async () => {
 };
 
 const dropEvents = async () => {
-  console.log('\n', '\x1b[0m', 'Dropping events collection...');
+  console.log('\n', '\x1b[0m', 'Dropping events and attendants collection...');
   if ((await Event.countDocuments()) !== 0) {
     await Event.collection.drop();
     console.log('\x1b[31m', 'Dropped events collection');
   } else {
     console.log('\x1b[33m', 'events collection is already empty');
+  }
+
+  if ((await Attendant.countDocuments()) !== 0) {
+    await Attendant.collection.drop();
+    console.log('\x1b[31m', 'Dropped attendants collection');
+  } else {
+    console.log('\x1b[33m', 'attendants collection is already empty');
   }
 };
 

--- a/api/db/helper-functions.js
+++ b/api/db/helper-functions.js
@@ -1,0 +1,39 @@
+const prompts = require('prompts');
+const countries = require('country-region-data');
+
+const createPrompt = async (message) => {
+  let answer = await prompts({
+    type: 'confirm',
+    name: 'value',
+    message,
+    initial: true,
+  });
+
+  return answer.value;
+};
+
+const getRandomDate = (startDate, endDate) =>
+  new Date(+startDate + Math.random() * (endDate - startDate));
+
+const getRandomCountry = (randomLocation) => 
+  randomLocation 
+    ? countries[Math.floor(Math.random() * countries.length)]
+    : { countryShortCode: 'ES' };
+
+const getRandomRegion = (randomLocation, country) => 
+  randomLocation
+    ? country.regions[Math.floor(Math.random() * country.regions.length)]
+    : { shortCode: 'M' };
+
+const getRandomInterests = (interests) =>
+  interests
+    .sort(() => 0.5 - Math.random())
+    .slice(0, Math.floor(Math.random() * interests.length));
+
+module.exports = { 
+  createPrompt,
+  getRandomDate,
+  getRandomCountry,
+  getRandomRegion,
+  getRandomInterests
+}

--- a/api/db/populate-events.js
+++ b/api/db/populate-events.js
@@ -79,8 +79,8 @@ const createEvents = async (multiplier, randomLocation, verbose) => {
 
     const startDate = getRandomDate(now, futureDate);
     const endDate = getRandomDate(
-      startDate,
-      new Date(startDate.getTime() + 60000)
+      new Date(startDate.getTime() + 60000),
+      new Date(startDate.getTime() + 86400000 * 2)
     );
 
     const country = getCountry(randomLocation);

--- a/api/db/populate-events.js
+++ b/api/db/populate-events.js
@@ -1,16 +1,22 @@
 const txtgen = require('txtgen');
 const { 
+  uniqueNamesGenerator,
+  adjectives,
+  animals,
+  starWars,
+  colors
+} = require('unique-names-generator');
+const { 
   createPrompt,
   getRandomDate,
-  getRandomCountry,
-  getRandomRegion ,
+  getCountry,
+  getRegion ,
   getRandomInterests
-} = require('./helper-functions');
+} = require('./utils');
 
 const Interest = require('../models/Interest');
 const User = require('../models/User');
 const Event = require('../models/Event');
-const { uniqueNamesGenerator, adjectives, animals, starWars, colors } = require('unique-names-generator');
 
 const createEvent = async (eventParams) => {
   const event = new Event({
@@ -20,8 +26,8 @@ const createEvent = async (eventParams) => {
     endDate: eventParams.endDate,
     country: eventParams.country,
     region: eventParams.region,
-    createdBy: eventParams.user,
-    relatedInterests: eventParams.interests,
+    createdBy: eventParams.createdBy,
+    relatedInterests: eventParams.relatedInterests,
     coverPhoto: eventParams.coverPhoto,
     attendantsLimit: eventParams.attendantsLimit,
   });
@@ -60,20 +66,21 @@ const createEvents = async (multiplier, randomLocation, verbose) => {
   const now = new Date();
   const futureDate = new Date().setFullYear(now.getFullYear() + 5);
 
-  for (let i = 0; i < 500 * multiplier; i++) {
+  for (let i = 0; i < 50 * multiplier; i++) {
     const name = uniqueNamesGenerator({
       dictionaries: [adjectives, animals, colors, starWars],
       length: 3,
+      style: 'capital',
       separator: ' '
     });
 
-    const description = txtgen.paragraph();
+    const description = txtgen.article(Math.floor(Math.random() * 15));
 
     const startDate = getRandomDate(now, futureDate);
     const endDate = getRandomDate(startDate, futureDate);
 
-    const country = getRandomCountry(randomLocation);
-    const region = getRandomRegion(randomLocation, country);
+    const country = getCountry(randomLocation);
+    const region = getRegion(randomLocation, country);
 
     const eventParams = {
       name,
@@ -82,10 +89,10 @@ const createEvents = async (multiplier, randomLocation, verbose) => {
       endDate,
       country: country.countryShortCode,
       region: region.shortCode,
-      user: usersList[Math.floor(Math.random() * usersList.length)],
-      interests: getRandomInterests(interestsList),
+      createdBy: usersList[Math.floor(Math.random() * usersList.length)],
+      relatedInterests: getRandomInterests(interestsList),
       coverPhoto: "",
-      attendantsLimit: Math.floor(Math.random() * usersList.length -1) + 1
+      attendantsLimit: Math.floor(Math.random() * (usersList.length - 2)) + 2
     };
 
     eventsArray.push(await createEvent(eventParams));

--- a/api/db/populate-events.js
+++ b/api/db/populate-events.js
@@ -1,17 +1,17 @@
 const txtgen = require('txtgen');
-const { 
+const {
   uniqueNamesGenerator,
   adjectives,
   animals,
   starWars,
-  colors
+  colors,
 } = require('unique-names-generator');
-const { 
+const {
   createPrompt,
   getRandomDate,
   getCountry,
-  getRegion ,
-  getRandomInterests
+  getRegion,
+  getRandomInterests,
 } = require('./utils');
 
 const Interest = require('../models/Interest');
@@ -63,6 +63,7 @@ const createEvents = async (multiplier, randomLocation, verbose) => {
 
   displayLogs = verbose;
   const eventsArray = [];
+
   const now = new Date();
   const futureDate = new Date().setFullYear(now.getFullYear() + 5);
 
@@ -71,15 +72,15 @@ const createEvents = async (multiplier, randomLocation, verbose) => {
       dictionaries: [adjectives, animals, colors, starWars],
       length: 3,
       style: 'capital',
-      separator: ' '
+      separator: ' ',
     });
 
     const description = txtgen.article(Math.floor(Math.random() * 2) + 1);
 
     const startDate = getRandomDate(now, futureDate);
     const endDate = getRandomDate(
-      startDate, 
-      new Date(startDate.getTime() + (86400000 * 2))
+      startDate,
+      new Date(startDate.getTime() + 86400000 * 2)
     );
 
     const country = getCountry(randomLocation);
@@ -94,8 +95,8 @@ const createEvents = async (multiplier, randomLocation, verbose) => {
       region: region.shortCode,
       createdBy: usersList[Math.floor(Math.random() * usersList.length)],
       relatedInterests: getRandomInterests(interestsList),
-      coverPhoto: "",
-      attendantsLimit: Math.floor(Math.random() * (usersList.length - 2)) + 2
+      coverPhoto: '',
+      attendantsLimit: Math.floor(Math.random() * (usersList.length - 2)) + 2,
     };
 
     eventsArray.push(await createEvent(eventParams));

--- a/api/db/populate-events.js
+++ b/api/db/populate-events.js
@@ -85,7 +85,7 @@ const createEvents = async (multiplier, randomLocation, verbose) => {
       user: usersList[Math.floor(Math.random() * usersList.length)],
       interests: getRandomInterests(interestsList),
       coverPhoto: "",
-      attendantsLimit: Math.floor(Math.random() * usersList.length) + 1
+      attendantsLimit: Math.floor(Math.random() * usersList.length -1) + 1
     };
 
     eventsArray.push(await createEvent(eventParams));

--- a/api/db/populate-events.js
+++ b/api/db/populate-events.js
@@ -1,0 +1,11 @@
+const prompts = require('prompts');
+
+const Interest = require('../models/Interest');
+const User = require('../models/User');
+const Event = require('../models/Event');
+
+const createEvent = async (eventParams) => {};
+
+const createEvents = async () => {};
+
+module.exports = { createEvents };

--- a/api/db/populate-events.js
+++ b/api/db/populate-events.js
@@ -74,10 +74,13 @@ const createEvents = async (multiplier, randomLocation, verbose) => {
       separator: ' '
     });
 
-    const description = txtgen.article(Math.floor(Math.random() * 15));
+    const description = txtgen.article(Math.floor(Math.random() * 2) + 1);
 
     const startDate = getRandomDate(now, futureDate);
-    const endDate = getRandomDate(startDate, futureDate);
+    const endDate = getRandomDate(
+      startDate, 
+      new Date(startDate.getTime() + (86400000 * 2))
+    );
 
     const country = getCountry(randomLocation);
     const region = getRegion(randomLocation, country);

--- a/api/db/populate-events.js
+++ b/api/db/populate-events.js
@@ -85,7 +85,7 @@ const createEvents = async (multiplier, randomLocation, verbose) => {
       user: usersList[Math.floor(Math.random() * usersList.length)],
       interests: getRandomInterests(interestsList),
       coverPhoto: "",
-      attendantsLimit: Math.floor(Math.random() * usersList.length)
+      attendantsLimit: Math.floor(Math.random() * usersList.length) + 1
     };
 
     eventsArray.push(await createEvent(eventParams));

--- a/api/db/populate-events.js
+++ b/api/db/populate-events.js
@@ -80,7 +80,7 @@ const createEvents = async (multiplier, randomLocation, verbose) => {
     const startDate = getRandomDate(now, futureDate);
     const endDate = getRandomDate(
       startDate,
-      new Date(startDate.getTime() + 86400000 * 2)
+      new Date(startDate.getTime() + 60000)
     );
 
     const country = getCountry(randomLocation);

--- a/api/db/populate-events.js
+++ b/api/db/populate-events.js
@@ -4,8 +4,61 @@ const Interest = require('../models/Interest');
 const User = require('../models/User');
 const Event = require('../models/Event');
 
-const createEvent = async (eventParams) => {};
+const createPrompt = async (message) => {
+  let answer = await prompts({
+    type: 'confirm',
+    name: 'value',
+    message,
+    initial: true,
+  });
 
-const createEvents = async () => {};
+  return answer.value;
+};
+
+const createEvent = async (eventParams) => {
+  const event = new Event({
+    name: eventParams.name,
+    description: eventParams.description,
+    startDate: eventParams.startDate,
+    endDate: eventParams.endDate,
+    country: eventParams.country,
+    region: eventParams.region,
+    createdBy: eventParams.user,
+    relatedInterests: eventParams.interests,
+    attendantsLimit: eventParams.attendantsLimit,
+  });
+  await event.save();
+
+  if (displayLogs) {
+    console.log('\n', '\x1b[0m', `New event created: ${event}`);
+  }
+};
+
+const createEvents = async (multiplier, randomLocation, verbose) => {
+  console.log('\n', '\x1b[0m', 'Populating events collection...');
+  displayLogs = verbose;
+
+  let usersList = await User.distinct('_id');
+  if (usersList.length === 0) {
+    console.log(
+      '\x1b[33m',
+      'The users collection does not exist. Aborted events collection population.'
+    );
+    return;
+  }
+
+  let interestsList = await Interest.distinct('_id');
+  if (interestsList.length === 0) {
+    const proceed = await createPrompt(
+      'The interests collection does not exist. Events created will not have any related interests. Do you want to continue?'
+    );
+    if (!proceed) {
+      console.log('\x1b[33m', 'Aborted events collection population');
+      return;
+    }
+  }
+
+  // createEvent();
+};
 
 module.exports = { createEvents };

--- a/api/db/populate-interests.js
+++ b/api/db/populate-interests.js
@@ -1,4 +1,4 @@
-const prompts = require('prompts');
+const { createPrompt } = require('./helper-functions');
 
 const Interest = require('../models/Interest');
 
@@ -28,14 +28,11 @@ const createInterests = async (verbose) => {
   displayLogs = verbose;
 
   if ((await Interest.countDocuments()) !== 0) {
-    const answer = await prompts({
-      type: 'confirm',
-      name: 'value',
-      message:
-        'The interests collection already exists. If you continue, the existing collection will be dropped to avoid duplication. Please note that this can break your application. Do you want to continue?',
-      initial: true,
-    });
-    if (answer.value) {
+    const proceed = await createPrompt(
+      'The interests collection already exists. If you continue, the existing collection will be dropped to avoid duplication. Please note that this can break your application. Do you want to continue?'
+    );
+    
+    if (proceed) {
       await Interest.collection.drop();
       console.log('\x1b[31m', 'Dropped old interests collection');
     } else {

--- a/api/db/populate-interests.js
+++ b/api/db/populate-interests.js
@@ -10,6 +10,7 @@ const categories = [
   'Shopping and fashion',
   'Sports',
 ];
+
 const interests = [];
 let displayLogs;
 
@@ -31,7 +32,7 @@ const createInterests = async (verbose) => {
     const proceed = await createPrompt(
       'The interests collection already exists. If you continue, the existing collection will be dropped to avoid duplication. Please note that this can break your application. Do you want to continue?'
     );
-    
+
     if (proceed) {
       await Interest.collection.drop();
       console.log('\x1b[31m', 'Dropped old interests collection');

--- a/api/db/populate-interests.js
+++ b/api/db/populate-interests.js
@@ -1,4 +1,4 @@
-const { createPrompt } = require('./helper-functions');
+const { createPrompt } = require('./utils');
 
 const Interest = require('../models/Interest');
 

--- a/api/db/populate-users.js
+++ b/api/db/populate-users.js
@@ -1,10 +1,9 @@
-const prompts = require('prompts');
+const { createPrompt, getRandomDate, getRandomCountry, getRandomRegion, getRandomInterests } = require('./helper-functions');
 
 const User = require('../models/User');
 const Interest = require('../models/Interest');
 
 const { uniqueNamesGenerator, names } = require('unique-names-generator');
-const countries = require('country-region-data');
 const locales = ['en', 'es'];
 let displayLogs;
 
@@ -28,9 +27,6 @@ const createUser = async (userParams) => {
     console.log('\n', '\x1b[0m', `New user created: ${user}`);
   }
 };
-
-const getRandomDate = (startDate, endDate) =>
-  new Date(+startDate + Math.random() * (endDate - startDate));
 
 const createAdminUser = () => {
   createUser({
@@ -66,14 +62,10 @@ const createUsers = async (multiplier, randomLocation, verbose) => {
   const usersArray = [];
 
   if (interestsList.length === 0) {
-    const answer = await prompts({
-      type: 'confirm',
-      name: 'value',
-      message:
-        'The interests collection does not exist. Users created will not have any interests. Do you want to continue?',
-      initial: true,
-    });
-    if (!answer.value) {
+    const proceed = await createPrompt(
+      'The interests collection does not exist. Users created will not have any interests. Do you want to continue?'
+    );
+    if (!proceed) {
       console.log('\x1b[33m', 'Aborted users collection population');
       return;
     }
@@ -88,12 +80,8 @@ const createUsers = async (multiplier, randomLocation, verbose) => {
       dictionaries: [names, names],
       separator: ' ',
     });
-    const country = randomLocation
-      ? countries[Math.floor(Math.random() * countries.length)]
-      : { countryShortCode: 'ES' };
-    const region = randomLocation
-      ? country.regions[Math.floor(Math.random() * country.regions.length)]
-      : { shortCode: 'M' };
+    const country = getRandomCountry(randomLocation);
+    const region = getRandomRegion(randomLocation, country);
 
     const userParams = {
       name,
@@ -107,9 +95,7 @@ const createUsers = async (multiplier, randomLocation, verbose) => {
         new Date(1970, 0, 1),
         new Date().setFullYear(now.getFullYear() - 13)
       ),
-      interests: interestsList
-        .sort(() => 0.5 - Math.random())
-        .slice(0, Math.floor(Math.random() * interestsList.length)),
+      interests: getRandomInterests(interestsList),
       admin: false,
     };
 

--- a/api/db/populate-users.js
+++ b/api/db/populate-users.js
@@ -1,9 +1,15 @@
-const { createPrompt, getRandomDate, getRandomCountry, getRandomRegion, getRandomInterests } = require('./helper-functions');
+const { 
+  createPrompt,
+  getRandomDate,
+  getCountry,
+  getRegion,
+  getRandomInterests
+} = require('./utils');
+const { uniqueNamesGenerator, names } = require('unique-names-generator');
 
 const User = require('../models/User');
 const Interest = require('../models/Interest');
 
-const { uniqueNamesGenerator, names } = require('unique-names-generator');
 const locales = ['en', 'es'];
 let displayLogs;
 
@@ -80,8 +86,8 @@ const createUsers = async (multiplier, randomLocation, verbose) => {
       dictionaries: [names, names],
       separator: ' ',
     });
-    const country = getRandomCountry(randomLocation);
-    const region = getRandomRegion(randomLocation, country);
+    const country = getCountry(randomLocation);
+    const region = getRegion(randomLocation, country);
 
     const userParams = {
       name,

--- a/api/db/populate-users.js
+++ b/api/db/populate-users.js
@@ -1,9 +1,9 @@
-const { 
+const {
   createPrompt,
   getRandomDate,
   getCountry,
   getRegion,
-  getRandomInterests
+  getRandomInterests,
 } = require('./utils');
 const { uniqueNamesGenerator, names } = require('unique-names-generator');
 
@@ -77,9 +77,7 @@ const createUsers = async (multiplier, randomLocation, verbose) => {
     }
   }
 
-  if (!(await User.exists({ email: 'admin@tisn.app' }))) {
-    createAdminUser();
-  }
+  if (!(await User.exists({ email: 'admin@tisn.app' }))) createAdminUser();
 
   for (let i = 0; i < 100 * multiplier; i++) {
     const name = uniqueNamesGenerator({

--- a/api/db/populate.js
+++ b/api/db/populate.js
@@ -2,6 +2,7 @@
 
 const minimist = require('minimist');
 const { connectDb, closeDb } = require('./connection');
+const { createEvents } = require('./populate-events');
 const { createInterests } = require('./populate-interests');
 const { createUsers } = require('./populate-users');
 
@@ -22,6 +23,7 @@ const populateCollections = async () => {
   connectDb();
   await createInterests(userArgs.v);
   await createUsers(userArgs.m, userArgs.r, userArgs.v);
+  await createEvents();
   closeDb();
 };
 
@@ -34,9 +36,12 @@ const populateCollection = async () => {
     case 'users':
       await createUsers(userArgs.m, userArgs.r, userArgs.v);
       break;
+    case 'events':
+      await createEvents();
+      break;
     default:
       console.log(
-        `Unknown collection '${userArgs.c}', possible options are: [interests, users]`
+        `Unknown collection '${userArgs.c}', possible options are: [interests, users, events]`
       );
       break;
   }

--- a/api/db/populate.js
+++ b/api/db/populate.js
@@ -23,7 +23,7 @@ const populateCollections = async () => {
   connectDb();
   await createInterests(userArgs.v);
   await createUsers(userArgs.m, userArgs.r, userArgs.v);
-  await createEvents();
+  await createEvents(userArgs.m, userArgs.r, userArgs.v);
   closeDb();
 };
 
@@ -37,7 +37,7 @@ const populateCollection = async () => {
       await createUsers(userArgs.m, userArgs.r, userArgs.v);
       break;
     case 'events':
-      await createEvents();
+      await createEvents(userArgs.m, userArgs.r, userArgs.v);
       break;
     default:
       console.log(

--- a/api/db/utils.js
+++ b/api/db/utils.js
@@ -13,14 +13,14 @@ const createPrompt = async (message) => {
 };
 
 const getRandomDate = (startDate, endDate) =>
-  new Date(+startDate + Math.random() * (endDate - startDate));
+  new Date(startDate.getTime() + Math.random() * (endDate - startDate));
 
-const getCountry = (random) => 
-  random 
+const getCountry = (random) =>
+  random
     ? countries[Math.floor(Math.random() * countries.length)]
     : { countryShortCode: 'ES' };
 
-const getRegion = (random, country) => 
+const getRegion = (random, country) =>
   random
     ? country.regions[Math.floor(Math.random() * country.regions.length)]
     : { shortCode: 'M' };
@@ -30,10 +30,10 @@ const getRandomInterests = (interests) =>
     .sort(() => 0.5 - Math.random())
     .slice(0, Math.floor(Math.random() * interests.length));
 
-module.exports = { 
+module.exports = {
   createPrompt,
   getRandomDate,
   getCountry,
   getRegion,
-  getRandomInterests
-}
+  getRandomInterests,
+};

--- a/api/db/utils.js
+++ b/api/db/utils.js
@@ -15,13 +15,13 @@ const createPrompt = async (message) => {
 const getRandomDate = (startDate, endDate) =>
   new Date(+startDate + Math.random() * (endDate - startDate));
 
-const getRandomCountry = (randomLocation) => 
-  randomLocation 
+const getCountry = (random) => 
+  random 
     ? countries[Math.floor(Math.random() * countries.length)]
     : { countryShortCode: 'ES' };
 
-const getRandomRegion = (randomLocation, country) => 
-  randomLocation
+const getRegion = (random, country) => 
+  random
     ? country.regions[Math.floor(Math.random() * country.regions.length)]
     : { shortCode: 'M' };
 
@@ -33,7 +33,7 @@ const getRandomInterests = (interests) =>
 module.exports = { 
   createPrompt,
   getRandomDate,
-  getRandomCountry,
-  getRandomRegion,
+  getCountry,
+  getRegion,
   getRandomInterests
 }

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -2743,6 +2743,12 @@
       "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
       "dev": true
     },
+    "txtgen": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/txtgen/-/txtgen-2.2.7.tgz",
+      "integrity": "sha512-vV65QydO0k+xbi0lB8FIpdVhtZ5rrtA6cDmxWwwDM5NIMiuEJZfurHPkXG7Q9fMIwHMNGfoePvjgtkknB8L2kQ==",
+      "dev": true
+    },
     "type-fest": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",

--- a/api/package.json
+++ b/api/package.json
@@ -48,8 +48,8 @@
     "nodemon": "^2.0.4",
     "prettier": "2.1.2",
     "prompts": "^2.3.2",
-    "unique-names-generator": "^4.3.1",
-    "txtgen": "^2.2.7"
+    "txtgen": "^2.2.7",
+    "unique-names-generator": "^4.3.1"
   },
   "husky": {
     "hooks": {

--- a/api/package.json
+++ b/api/package.json
@@ -48,7 +48,8 @@
     "nodemon": "^2.0.4",
     "prettier": "2.1.2",
     "prompts": "^2.3.2",
-    "unique-names-generator": "^4.3.1"
+    "unique-names-generator": "^4.3.1",
+    "txtgen": "^2.2.7"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Refer #279. Populate and drop events.

Things to note:
1. When dropping the events collection, I also have it dropping the attendants collection as it is completely dependent on the event.
2. When populating the events, I worked under the assumption that the start dates would range between now (`new Date()`) and 5 years from now (`futureDate`). End date ranges between start date and `futureDate`. 
3. I refactored a lot of code that is and will be reusable between all the population scripts and put them in a `helper-functions.js` file. 
4. I set the maximum attendantsLimit to the total number of users at the time of population, though I know it is arbitrary. I did this so we can more easily test and create functionality around having full events. If we were to set it to be a random number between 1 and 1 million, it would be difficult to find events to test such functionality.