### PR TITLE
Populate (and drop) the notifications collection

### DIFF
--- a/api/db/drop.js
+++ b/api/db/drop.js
@@ -163,14 +163,14 @@ const dropNotifications = async (confirmed = false) => {
     await Notification.collection.drop();
     console.log('\x1b[31m', 'Dropped notifications collection');
   } else {
-    console.log('\x1b[31m', 'Notifications collection is already empty');
+    console.log('\x1b[33m', 'Notifications collection is already empty');
   }
 };
 
 const dropCollections = async () => {
   connectDb();
-  await dropMessages();
   await dropNotifications();
+  await dropMessages();
   await dropFriendships();
   await dropComments();
   await dropAttendants();

--- a/api/db/drop.js
+++ b/api/db/drop.js
@@ -11,6 +11,7 @@ const Attendant = require('../models/Attendant');
 const Comment = require('../models/Comment');
 const Friendship = require('../models/Friendship');
 const Message = require('../models/Message');
+const Notification = require('../models/Notification');
 
 const getInterestsCount = async () => await Interest.countDocuments();
 const getUsersCount = async () => await User.countDocuments();
@@ -19,6 +20,7 @@ const getAttendantsCount = async () => await Attendant.countDocuments();
 const getCommentsCount = async () => await Comment.countDocuments();
 const getFriendshipsCount = async () => await Friendship.countDocuments();
 const getMessagesCount = async () => await Message.countDocuments();
+const getNotificationsCount = async () => await Notification.countDocuments();
 
 const userArgs = minimist(process.argv.slice(2), {
   string: 'collection',
@@ -69,6 +71,14 @@ const dropUsers = async (confirmed = false) => {
     );
 
     if (drop) await dropFriendships(drop);
+  }
+
+  if ((await getNotificationsCount()) !== 0) {
+    const drop = await createPrompt(
+      'The notifications collection is dependent on the users collection. Drop notifications collection?'
+    );
+
+    if (drop) await dropNotifications(drop);
   }
 };
 
@@ -147,9 +157,20 @@ const dropMessages = async (confirmed = false) => {
   }
 };
 
+const dropNotifications = async (confirmed = false) => {
+  console.log('\n', '\x1b[0m', 'Dropping notifications collection');
+  if (confirmed || (await getNotificationsCount()) !== 0) {
+    await Notification.collection.drop();
+    console.log('\x1b[31m', 'Dropped notifications collection');
+  } else {
+    console.log('\x1b[31m', 'Notifications collection is already empty');
+  }
+};
+
 const dropCollections = async () => {
   connectDb();
   await dropMessages();
+  await dropNotifications();
   await dropFriendships();
   await dropComments();
   await dropAttendants();
@@ -183,9 +204,12 @@ const dropCollection = async () => {
     case 'messages':
       await dropMessages();
       break;
+    case 'notifications':
+      await dropNotifications();
+      break;
     default:
       console.log(
-        `Unknown collection '${userArgs.c}', possible options are: [interests, users, events, attendants, comments, friendships, messages]`
+        `Unknown collection '${userArgs.c}', possible options are: [interests, users, events, attendants, comments, friendships, messages, notifications]`
       );
       break;
   }

--- a/api/db/populate-attendants.js
+++ b/api/db/populate-attendants.js
@@ -15,13 +15,16 @@ const createAttendant = async (attendantParams) => {
   await attendant.save();
 
   // New attendee notification
-  await createNotification({
-    user: attendantParams.event.createdBy,
-    type: notificationTypes[4],
-    read: false,
-    referencedUser: attendant.user,
-    referencedEvent: attendant.event,
-  });
+  await createNotification(
+    {
+      user: attendantParams.event.createdBy,
+      type: notificationTypes[4],
+      read: false,
+      referencedUser: attendant.user,
+      referencedEvent: attendant.event,
+    },
+    displayLogs
+  );
 
   if (displayLogs) {
     console.log('\n', '\x1b[0m', `New attendant created: ${attendant}`);

--- a/api/db/populate-attendants.js
+++ b/api/db/populate-attendants.js
@@ -1,4 +1,5 @@
 const { getRandomSubset, createPrompt } = require('./utils');
+const { createNotification } = require('./populate-notifications');
 
 const User = require('../models/User');
 const Event = require('../models/Event');
@@ -7,11 +8,17 @@ const Attendant = require('../models/Attendant');
 let displayLogs;
 
 const createAttendant = async (attendantParams) => {
-  const attendant = new Attendant({
-    event: attendantParams.event,
-    user: attendantParams.user,
-  });
+  const attendant = new Attendant(attendantParams);
   await attendant.save();
+
+  // New attendee notification
+  await createNotification({
+    user: attendantParams.event.createdBy,
+    type: 'newAttendant',
+    read: false,
+    referencedUser: attendant.user,
+    referencedEvent: attendant.event,
+  });
 
   if (displayLogs) {
     console.log('\n', '\x1b[0m', `New attendant created: ${attendant}`);

--- a/api/db/populate-attendants.js
+++ b/api/db/populate-attendants.js
@@ -9,22 +9,26 @@ const Event = require('../models/Event');
 const Attendant = require('../models/Attendant');
 
 let displayLogs;
+let notificationsCount = 0;
 
 const createAttendant = async (attendantParams) => {
   const attendant = new Attendant(attendantParams);
   await attendant.save();
 
   // New attendee notification
-  await createNotification(
-    {
-      user: attendantParams.event.createdBy,
-      type: notificationTypes[4],
-      read: false,
-      referencedUser: attendant.user,
-      referencedEvent: attendant.event,
-    },
-    displayLogs
-  );
+  if (attendant.user.toString() !== attendant.event.createdBy.toString()) {
+    await createNotification(
+      {
+        user: attendant.event.createdBy,
+        type: notificationTypes[4],
+        read: false,
+        referencedUser: attendant.user,
+        referencedEvent: attendant.event,
+      },
+      displayLogs
+    );
+    notificationsCount++;
+  }
 
   if (displayLogs) {
     console.log('\n', '\x1b[0m', `New attendant created: ${attendant}`);
@@ -100,6 +104,10 @@ const createAttendants = async (verbose) => {
   }
 
   console.log('\x1b[32m', `Created ${attendantsArray.length} attendants`);
+  console.log(
+    '\x1b[32m',
+    `Created ${notificationsCount} attendant notifications`
+  );
 };
 
 module.exports = { createAttendants };

--- a/api/db/populate-attendants.js
+++ b/api/db/populate-attendants.js
@@ -1,5 +1,8 @@
 const { getRandomSubset, createPrompt } = require('./utils');
-const { createNotification } = require('./populate-notifications');
+const {
+  createNotification,
+  notificationTypes,
+} = require('./populate-notifications');
 
 const User = require('../models/User');
 const Event = require('../models/Event');
@@ -14,7 +17,7 @@ const createAttendant = async (attendantParams) => {
   // New attendee notification
   await createNotification({
     user: attendantParams.event.createdBy,
-    type: 'newAttendant',
+    type: notificationTypes[4],
     read: false,
     referencedUser: attendant.user,
     referencedEvent: attendant.event,

--- a/api/db/populate-attendants.js
+++ b/api/db/populate-attendants.js
@@ -103,10 +103,9 @@ const createAttendants = async (verbose) => {
     }
   }
 
-  console.log('\x1b[32m', `Created ${attendantsArray.length} attendants`);
   console.log(
     '\x1b[32m',
-    `Created ${notificationsCount} attendant notifications`
+    `Created ${attendantsArray.length} attendants (and ${notificationsCount} related notifications)`
   );
 };
 

--- a/api/db/populate-comments.js
+++ b/api/db/populate-comments.js
@@ -35,10 +35,7 @@ const prerequisites = (eventsCount, attendantsCount) => {
 };
 
 const getParentComment = (comments) => {
-  const parentComments = comments.filter(
-    (comment) =>
-      comment.parentComment === undefined || comment.parentComment === null
-  );
+  const parentComments = comments.filter((comment) => !comment.parentComment);
   return parentComments[Math.floor(Math.random() * parentComments.length)];
 };
 
@@ -109,10 +106,9 @@ const createComments = async (verbose) => {
     }
   }
 
-  console.log('\x1b[32m', `Created ${commentsArray.length} comments`);
   console.log(
     '\x1b[32m',
-    `Created ${notificationsCount} comment notifications`
+    `Created ${commentsArray.length} comments (and ${notificationsCount} related notifications)`
   );
 };
 

--- a/api/db/populate-comments.js
+++ b/api/db/populate-comments.js
@@ -82,8 +82,8 @@ const createComments = async (verbose) => {
         event,
         user,
         content,
-        parentComment,
       };
+      if (parentComment) commentParams.parentComment = parentComment;
 
       const comment = await createComment(commentParams);
       eventComments.push(comment);

--- a/api/db/populate-comments.js
+++ b/api/db/populate-comments.js
@@ -95,13 +95,16 @@ const createComments = async (verbose) => {
 
       for (const attendee of eventAttendants) {
         if (attendee.user.toString() === comment.user.toString()) continue;
-        await createNotification({
-          user: attendee.user,
-          type: notificationTypes[5],
-          read: true,
-          referencedUser: comment.user,
-          referencedEvent: comment.event,
-        });
+        await createNotification(
+          {
+            user: attendee.user,
+            type: notificationTypes[5],
+            read: true,
+            referencedUser: comment.user,
+            referencedEvent: comment.event,
+          },
+          displayLogs
+        );
       }
     }
   }

--- a/api/db/populate-comments.js
+++ b/api/db/populate-comments.js
@@ -1,14 +1,15 @@
 const { getParagraph } = require('./utils');
-
-const Event = require('../models/Event');
-const Attendant = require('../models/Attendant');
-const Comment = require('../models/Comment');
 const {
   createNotification,
   notificationTypes,
 } = require('./populate-notifications');
 
+const Event = require('../models/Event');
+const Attendant = require('../models/Attendant');
+const Comment = require('../models/Comment');
+
 let displayLogs;
+let notificationsCount = 0;
 
 const prerequisites = (eventsCount, attendantsCount) => {
   if (eventsCount === 0 && attendantsCount === 0) {
@@ -42,9 +43,6 @@ const getParentComment = (comments) => {
 
 const createComment = async (commentParams) => {
   const comment = new Comment(commentParams);
-  if (commentParams.parentComment) {
-    comment.parentComment = commentParams.parentComment;
-  }
   await comment.save();
 
   if (displayLogs) {
@@ -99,17 +97,22 @@ const createComments = async (verbose) => {
           {
             user: attendee.user,
             type: notificationTypes[5],
-            read: true,
+            read: false,
             referencedUser: comment.user,
             referencedEvent: comment.event,
           },
           displayLogs
         );
+        notificationsCount++;
       }
     }
   }
 
   console.log('\x1b[32m', `Created ${commentsArray.length} comments`);
+  console.log(
+    '\x1b[32m',
+    `Created ${notificationsCount} comment notifications`
+  );
 };
 
 module.exports = { createComments };

--- a/api/db/populate-comments.js
+++ b/api/db/populate-comments.js
@@ -3,7 +3,10 @@ const { getParagraph } = require('./utils');
 const Event = require('../models/Event');
 const Attendant = require('../models/Attendant');
 const Comment = require('../models/Comment');
-const { createNotification } = require('./populate-notifications');
+const {
+  createNotification,
+  notificationTypes,
+} = require('./populate-notifications');
 
 let displayLogs;
 
@@ -94,7 +97,7 @@ const createComments = async (verbose) => {
         if (attendee.user.toString() === comment.user.toString()) continue;
         await createNotification({
           user: attendee.user,
-          type: 'newComment',
+          type: notificationTypes[5],
           read: true,
           referencedUser: comment.user,
           referencedEvent: comment.event,

--- a/api/db/populate-comments.js
+++ b/api/db/populate-comments.js
@@ -36,7 +36,8 @@ const prerequisites = (eventsCount, attendantsCount) => {
 
 const getParentComment = (comments) => {
   const parentComments = comments.filter(
-    (comment) => comment.parentComment === undefined
+    (comment) =>
+      comment.parentComment === undefined || comment.parentComment === null
   );
   return parentComments[Math.floor(Math.random() * parentComments.length)];
 };

--- a/api/db/populate-events.js
+++ b/api/db/populate-events.js
@@ -13,6 +13,7 @@ const {
   getRegion,
   getRandomSubset,
 } = require('./utils');
+const { notificationTypes } = require('./populate-notifications');
 
 const Interest = require('../models/Interest');
 const User = require('../models/User');
@@ -100,7 +101,7 @@ const createEvents = async (multiplier, randomLocation, verbose) => {
   ];
   for (const creator of uniqueEventCreators) {
     await Notification.findOneAndUpdate(
-      { user: creator, type: 'createEvent' },
+      { user: creator, type: notificationTypes[1] },
       { read: true }
     );
   }

--- a/api/db/populate-events.js
+++ b/api/db/populate-events.js
@@ -17,22 +17,12 @@ const {
 const Interest = require('../models/Interest');
 const User = require('../models/User');
 const Event = require('../models/Event');
+const Notification = require('../models/Notification');
 
 let displayLogs;
 
 const createEvent = async (eventParams) => {
-  const event = new Event({
-    name: eventParams.name,
-    description: eventParams.description,
-    startDate: eventParams.startDate,
-    endDate: eventParams.endDate,
-    country: eventParams.country,
-    region: eventParams.region,
-    createdBy: eventParams.createdBy,
-    relatedInterests: eventParams.relatedInterests,
-    coverPhoto: eventParams.coverPhoto,
-    attendantsLimit: eventParams.attendantsLimit,
-  });
+  const event = new Event(eventParams);
   await event.save();
 
   if (displayLogs) {
@@ -103,6 +93,16 @@ const createEvents = async (multiplier, randomLocation, verbose) => {
     };
 
     eventsArray.push(await createEvent(eventParams));
+  }
+
+  const uniqueEventCreators = [
+    ...new Set(eventsArray.map((event) => event.createdBy)),
+  ];
+  for (const creator of uniqueEventCreators) {
+    await Notification.findOneAndUpdate(
+      { user: creator, type: 'createEvent' },
+      { read: true }
+    );
   }
 
   console.log('\x1b[32m', `Created ${eventsArray.length} events`);

--- a/api/db/populate-events.js
+++ b/api/db/populate-events.js
@@ -99,9 +99,9 @@ const createEvents = async (multiplier, randomLocation, verbose) => {
   const uniqueEventCreators = [
     ...new Set(eventsArray.map((event) => event.createdBy)),
   ];
-  for (const creator of uniqueEventCreators) {
+  for (const eventCreator of uniqueEventCreators) {
     await Notification.findOneAndUpdate(
-      { user: creator, type: notificationTypes[1] },
+      { user: eventCreator, type: notificationTypes[1] },
       { read: true }
     );
   }

--- a/api/db/populate-events.js
+++ b/api/db/populate-events.js
@@ -3,7 +3,6 @@ const {
   uniqueNamesGenerator,
   adjectives,
   animals,
-  starWars,
   colors,
 } = require('unique-names-generator');
 const {
@@ -63,8 +62,7 @@ const createEvents = async (multiplier, randomLocation, verbose) => {
 
   for (let i = 0; i < 50 * multiplier; i++) {
     const name = uniqueNamesGenerator({
-      dictionaries: [adjectives, animals, colors, starWars],
-      length: 3,
+      dictionaries: [adjectives, colors, animals],
       style: 'capital',
       separator: ' ',
     });

--- a/api/db/populate-friendships.js
+++ b/api/db/populate-friendships.js
@@ -14,21 +14,27 @@ const createFriendship = async (friendshipParams) => {
   await friendship.save();
 
   // New friendship request notifications
-  await createNotification({
-    user: friendship.receivant,
-    type: notificationTypes[6],
-    read: friendship.accepted,
-    referencedUser: friendship.requestant,
-    referencedFriendship: friendship,
-  });
-  if (friendship.accepted) {
-    await createNotification({
-      user: friendship.requestant,
-      type: notificationTypes[7],
-      read: Math.random() > 0.3,
-      referencedUser: friendship.receivant,
+  await createNotification(
+    {
+      user: friendship.receivant,
+      type: notificationTypes[6],
+      read: friendship.accepted,
+      referencedUser: friendship.requestant,
       referencedFriendship: friendship,
-    });
+    },
+    displayLogs
+  );
+  if (friendship.accepted) {
+    await createNotification(
+      {
+        user: friendship.requestant,
+        type: notificationTypes[7],
+        read: Math.random() > 0.3,
+        referencedUser: friendship.receivant,
+        referencedFriendship: friendship,
+      },
+      displayLogs
+    );
   }
 
   if (displayLogs) {

--- a/api/db/populate-friendships.js
+++ b/api/db/populate-friendships.js
@@ -85,11 +85,9 @@ const createFriendships = async (verbose) => {
   }
   console.log(
     '\x1b[32m',
-    `Created ${friendshipsArray.length - documentsCount} friendships`
-  );
-  console.log(
-    '\x1b[32m',
-    `Created ${notificationsCount} friendship notifications`
+    `Created ${
+      friendshipsArray.length - documentsCount
+    } friendships (and ${notificationsCount} related notifications)`
   );
 };
 

--- a/api/db/populate-friendships.js
+++ b/api/db/populate-friendships.js
@@ -8,6 +8,7 @@ const User = require('../models/User');
 const Friendship = require('../models/Friendship');
 
 let displayLogs;
+let notificationsCount = 0;
 
 const createFriendship = async (friendshipParams) => {
   const friendship = new Friendship(friendshipParams);
@@ -24,6 +25,8 @@ const createFriendship = async (friendshipParams) => {
     },
     displayLogs
   );
+  notificationsCount++;
+  // Accepted friendship request notifications
   if (friendship.accepted) {
     await createNotification(
       {
@@ -35,6 +38,7 @@ const createFriendship = async (friendshipParams) => {
       },
       displayLogs
     );
+    notificationsCount++;
   }
 
   if (displayLogs) {
@@ -82,6 +86,10 @@ const createFriendships = async (verbose) => {
   console.log(
     '\x1b[32m',
     `Created ${friendshipsArray.length - documentsCount} friendships`
+  );
+  console.log(
+    '\x1b[32m',
+    `Created ${notificationsCount} friendship notifications`
   );
 };
 

--- a/api/db/populate-friendships.js
+++ b/api/db/populate-friendships.js
@@ -1,5 +1,8 @@
 const { getRandomSubset, getRandomDate } = require('./utils');
-const { createNotification } = require('./populate-notifications');
+const {
+  createNotification,
+  notificationTypes,
+} = require('./populate-notifications');
 
 const User = require('../models/User');
 const Friendship = require('../models/Friendship');
@@ -13,7 +16,7 @@ const createFriendship = async (friendshipParams) => {
   // New friendship request notifications
   await createNotification({
     user: friendship.receivant,
-    type: 'newFriendshipRequest',
+    type: notificationTypes[6],
     read: friendship.accepted,
     referencedUser: friendship.requestant,
     referencedFriendship: friendship,
@@ -21,7 +24,7 @@ const createFriendship = async (friendshipParams) => {
   if (friendship.accepted) {
     await createNotification({
       user: friendship.requestant,
-      type: 'acceptedFriendshipRequest',
+      type: notificationTypes[7],
       read: Math.random() > 0.3,
       referencedUser: friendship.receivant,
       referencedFriendship: friendship,

--- a/api/db/populate-messages.js
+++ b/api/db/populate-messages.js
@@ -8,13 +8,10 @@ const Friendship = require('../models/Friendship');
 const Message = require('../models/Message');
 
 let displayLogs;
+let notificationsCount = 0;
 
 const createMessage = async (messageParams) => {
-  const message = new Message({
-    friendship: messageParams.friendship,
-    user: messageParams.user,
-    content: messageParams.content,
-  });
+  const message = new Message(messageParams);
   await message.save();
 
   const user =
@@ -31,6 +28,7 @@ const createMessage = async (messageParams) => {
     },
     displayLogs
   );
+  notificationsCount++;
 
   if (displayLogs) {
     console.log('\n', '\x1b[0m', `New message created: ${message}`);
@@ -69,6 +67,10 @@ const createMessages = async (verbose) => {
   }
 
   console.log('\x1b[32m', `Created ${messagesArray.length} messages`);
+  console.log(
+    '\x1b[32m',
+    `Created ${notificationsCount} message notifications`
+  );
 };
 
 module.exports = { createMessages };

--- a/api/db/populate-messages.js
+++ b/api/db/populate-messages.js
@@ -16,19 +16,21 @@ const createMessage = async (messageParams) => {
 
   const user =
     message.friendship.receivant.toString() === message.user.toString()
-      ? message.friendship.receivant
-      : message.friendship.requestant;
-  await createNotification(
-    {
-      user,
-      type: notificationTypes[8],
-      read: false,
-      referencedUser: message.user,
-      referencedFriendship: message.friendship,
-    },
-    displayLogs
-  );
-  notificationsCount++;
+      ? message.friendship.requestant
+      : message.friendship.receivant;
+  if (!message.friendship.accepted) {
+    await createNotification(
+      {
+        user,
+        type: notificationTypes[8],
+        read: false,
+        referencedUser: message.user,
+        referencedFriendship: message.friendship,
+      },
+      displayLogs
+    );
+    notificationsCount++;
+  }
 
   if (displayLogs) {
     console.log('\n', '\x1b[0m', `New message created: ${message}`);
@@ -66,10 +68,9 @@ const createMessages = async (verbose) => {
     }
   }
 
-  console.log('\x1b[32m', `Created ${messagesArray.length} messages`);
   console.log(
     '\x1b[32m',
-    `Created ${notificationsCount} message notifications`
+    `Created ${messagesArray.length} messages (and ${notificationsCount} related notifications)`
   );
 };
 

--- a/api/db/populate-messages.js
+++ b/api/db/populate-messages.js
@@ -1,4 +1,5 @@
 const { getParagraph } = require('./utils');
+const { createNotification } = require('./populate-notifications');
 
 const Friendship = require('../models/Friendship');
 const Message = require('../models/Message');
@@ -12,6 +13,18 @@ const createMessage = async (messageParams) => {
     content: messageParams.content,
   });
   await message.save();
+
+  const user =
+    message.friendship.receivant.toString() === message.user.toString()
+      ? message.friendship.receivant
+      : message.friendship.requestant;
+  await createNotification({
+    user,
+    type: 'newMessage',
+    read: false,
+    referencedUser: message.user,
+    referencedFriendship: message.friendship,
+  });
 
   if (displayLogs) {
     console.log('\n', '\x1b[0m', `New message created: ${message}`);

--- a/api/db/populate-messages.js
+++ b/api/db/populate-messages.js
@@ -18,19 +18,17 @@ const createMessage = async (messageParams) => {
     message.friendship.receivant.toString() === message.user.toString()
       ? message.friendship.requestant
       : message.friendship.receivant;
-  if (!message.friendship.accepted) {
-    await createNotification(
-      {
-        user,
-        type: notificationTypes[8],
-        read: false,
-        referencedUser: message.user,
-        referencedFriendship: message.friendship,
-      },
-      displayLogs
-    );
-    notificationsCount++;
-  }
+  await createNotification(
+    {
+      user,
+      type: notificationTypes[8],
+      read: false,
+      referencedUser: message.user,
+      referencedFriendship: message.friendship,
+    },
+    displayLogs
+  );
+  notificationsCount++;
 
   if (displayLogs) {
     console.log('\n', '\x1b[0m', `New message created: ${message}`);
@@ -46,6 +44,7 @@ const createMessages = async (verbose) => {
   const messagesArray = [];
 
   for (const friendship of friendshipsArray) {
+    if (!friendship.accepted) continue;
     const messagesCount = Math.floor(Math.random() * 25);
 
     for (let i = 0; i < messagesCount; i++) {

--- a/api/db/populate-messages.js
+++ b/api/db/populate-messages.js
@@ -21,13 +21,16 @@ const createMessage = async (messageParams) => {
     message.friendship.receivant.toString() === message.user.toString()
       ? message.friendship.receivant
       : message.friendship.requestant;
-  await createNotification({
-    user,
-    type: notificationTypes[8],
-    read: false,
-    referencedUser: message.user,
-    referencedFriendship: message.friendship,
-  });
+  await createNotification(
+    {
+      user,
+      type: notificationTypes[8],
+      read: false,
+      referencedUser: message.user,
+      referencedFriendship: message.friendship,
+    },
+    displayLogs
+  );
 
   if (displayLogs) {
     console.log('\n', '\x1b[0m', `New message created: ${message}`);

--- a/api/db/populate-messages.js
+++ b/api/db/populate-messages.js
@@ -1,5 +1,8 @@
 const { getParagraph } = require('./utils');
-const { createNotification } = require('./populate-notifications');
+const {
+  createNotification,
+  notificationTypes,
+} = require('./populate-notifications');
 
 const Friendship = require('../models/Friendship');
 const Message = require('../models/Message');
@@ -20,7 +23,7 @@ const createMessage = async (messageParams) => {
       : message.friendship.requestant;
   await createNotification({
     user,
-    type: 'newMessage',
+    type: notificationTypes[8],
     read: false,
     referencedUser: message.user,
     referencedFriendship: message.friendship,

--- a/api/db/populate-notifications.js
+++ b/api/db/populate-notifications.js
@@ -1,15 +1,6 @@
-const { createPrompt } = require('./utils');
-
-const User = require('../models/User');
-const Interest = require('../models/Interest');
-const Event = require('../models/Event');
-const Attendant = require('../models/Attendant');
-const Comment = require('../models/Comment');
-const Friendship = require('../models/Friendship');
-const Message = require('../models/Message');
 const Notification = require('../models/Notification');
 
-const types = [
+const notificationTypes = [
   'confirmEmail',
   'createEvent',
   'uploadAvatar',
@@ -21,187 +12,16 @@ const types = [
   'newMessage',
 ];
 
-const createNotification = async (notificationParams) => {
+const createNotification = async (notificationParams, verbose = false) => {
   const notification = new Notification(notificationParams);
   if (notification.read) notification.readAt = new Date();
 
   await notification.save();
 
-  // if (displayLogs) {
-  //   console.log('\n', '\x1b[0m', `New notification created: ${notification}`);
-  // }
+  if (verbose) {
+    console.log('\n', '\x1b[0m', `New notification created: ${notification}`);
+  }
   return notification;
 };
 
-const createNotifications = async (verbose) => {
-  console.log('\n', '\x1b[0m', 'Populating notifications collection...');
-  displayLogs = verbose;
-
-  if ((await Notification.countDocuments()) !== 0) {
-    const proceed = await createPrompt(
-      'The notifications collection already exists. If you continue, the existing collection will be dropped to avoid duplication. Do you want to continue?'
-    );
-
-    if (proceed) {
-      await Notification.collection.drop();
-      console.log('\x1b[31m', 'Dropped old notifications collection');
-    } else {
-      console.log('\x1b[33m', 'Aborted notifications collection population');
-      return;
-    }
-  }
-
-  const notificationsArray = [];
-  const usersList = await User.find();
-  const eventsList = await Event.find();
-  const attendantsList = await Attendant.find();
-  const commentsList = await Comment.find();
-  const friendshipsList = await Friendship.find();
-  const messagesList = await Message.find();
-
-  // For each user
-  for (const user of usersList) {
-    let read = user.emailConfirmed;
-    // Confirm email notification
-    notificationsArray.push(
-      await createNotification({
-        user,
-        type: types[0],
-        read,
-      })
-    );
-    // Create event notification
-    const userEvents = eventsList.filter(
-      (event) => event.createdBy.toString() === user._id.toString()
-    );
-    read = userEvents.length > 0;
-    notificationsArray.push(
-      await createNotification({
-        user,
-        type: types[1],
-        read,
-      })
-    );
-    // Upload avatar notification
-    read = user.avatar ? true : false;
-    notificationsArray.push(
-      await createNotification({
-        user,
-        type: types[2],
-        read,
-      })
-    );
-    // Select interests notification
-    read = user.interests.length > 0;
-    notificationsArray.push(
-      await createNotification({
-        user,
-        type: types[3],
-        read,
-      })
-    );
-
-    // New attendee and new comment notifications
-    for (const event of userEvents) {
-      const attendees = attendantsList.filter(
-        (attendee) =>
-          attendee.event.toString() === event._id.toString() &&
-          attendee.user.toString() !== user._id.toString()
-      );
-      for (const attendee of attendees) {
-        read = Math.random() > 0.5;
-        const notificationParams = {
-          user,
-          type: types[4],
-          read,
-          referencedUser: attendee.user,
-          referencedEvent: event,
-        };
-        notificationsArray.push(await createNotification(notificationParams));
-
-        const comments = commentsList.filter(
-          (comment) =>
-            comment.event.toString() === event._id.toString() &&
-            comment.user.toString() !== user._id.toString()
-        );
-        for (const comment of comments) {
-          if (attendee.user.toString() === comment.user.toString()) continue;
-          read = Math.random() > 0.5;
-          const notificationParams = {
-            user: attendee.user,
-            type: types[5],
-            read,
-            referencedUser: comment.user,
-            referencedEvent: comment.event,
-          };
-          notificationsArray.push(await createNotification(notificationParams));
-        }
-      }
-    }
-
-    // New friendship request notifications
-    const friendshipRequests = friendshipsList.filter(
-      (friendship) =>
-        !friendship.accepted &&
-        friendship.receivant.toString() === user._id.toString()
-    );
-    for (const friendRequest of friendshipRequests) {
-      read = Math.random() > 0.5;
-      const notificationParams = {
-        user,
-        type: types[6],
-        read,
-        referencedUser: friendRequest.requestant,
-        referencedFriendship: friendRequest,
-      };
-      notificationsArray.push(await createNotification(notificationParams));
-    }
-
-    // Accepted friendship request notifications
-    const acceptedFriendshipRequests = friendshipsList.filter(
-      (friendship) =>
-        friendship.accepted &&
-        friendship.requestant.toString() === user._id.toString()
-    );
-    for (const acceptedFriendship of acceptedFriendshipRequests) {
-      read = Math.random() > 0.5;
-      const notificationParams = {
-        user,
-        type: types[7],
-        read,
-        referencedUser: acceptedFriendship.receivant,
-        referencedFriendship: acceptedFriendship,
-      };
-      notificationsArray.push(await createNotification(notificationParams));
-    }
-
-    // New message notifications
-    const userFriendships = friendshipsList.filter(
-      (friendship) =>
-        friendship.requestant.toString() === user._id.toString() ||
-        friendship.receivant.toString() === user._id.toString()
-    );
-    for (const userfriendship of userFriendships) {
-      const messages = messagesList.filter(
-        (message) =>
-          message.friendship.toString() === userfriendship._id.toString() &&
-          message.user.toString() !== user._id.toString()
-      );
-      for (const message of messages) {
-        read = Math.random() > 0.9;
-        const notificationParams = {
-          user,
-          type: types[8],
-          read,
-          referencedUser: message.user,
-          referencedFriendship: message.friendship,
-        };
-        notificationsArray.push(await createNotification(notificationParams));
-      }
-    }
-  }
-
-  console.log('\x1b[32m', `Created ${notificationsArray.length} notifications`);
-};
-
-module.exports = { createNotification, createNotifications };
+module.exports = { createNotification, notificationTypes };

--- a/api/db/populate-notifications.js
+++ b/api/db/populate-notifications.js
@@ -42,50 +42,45 @@ const getNewAttendant = (user) => {
 const getNewComment = (user) => {
   const event = getEvent(user);
   if (!event) return;
-  const comments = commentsList.filter((comment) => {
-    return (
+  const comments = commentsList.filter(
+    (comment) =>
       comment.event.toString() === event._id.toString() &&
       comment.user.toString() !== user._id.toString()
-    );
-  });
+  );
   return comments[Math.floor(Math.random() * comments.length)];
 };
 
 const getNewFriendRequest = (user) => {
-  const friendships = friendshipsList.filter((friendship) => {
-    return (
+  const friendships = friendshipsList.filter(
+    (friendship) =>
       !friendship.accepted &&
       friendship.receivant.toString() === user._id.toString()
-    );
-  });
+  );
   return friendships[Math.floor(Math.random() * friendships.length)];
 };
 
 const getAcceptedFriendRequest = (user) => {
-  const friendships = friendshipsList.filter((friendship) => {
-    return (
+  const friendships = friendshipsList.filter(
+    (friendship) =>
       friendship.accepted &&
       friendship.requestant.toString() === user._id.toString()
-    );
-  });
+  );
   return friendships[Math.floor(Math.random() * friendships.length)];
 };
 
 const getNewMessage = (user) => {
-  const friendships = friendshipsList.filter((friendship) => {
-    return (
+  const friendships = friendshipsList.filter(
+    (friendship) =>
       friendship.requestant.toString() === user._id.toString() ||
       friendship.receivant.toString() === user._id.toString()
-    );
-  });
+  );
   const friendship =
     friendships[Math.floor(Math.random() * friendships.length)];
-  const messages = messagesList.filter((message) => {
-    return (
+  const messages = messagesList.filter(
+    (message) =>
       message.friendship.toString() === friendship._id.toString() &&
       message.user.toString() !== user._id.toString()
-    );
-  });
+  );
   return messages[Math.floor(Math.random() * messages.length)];
 };
 

--- a/api/db/populate-notifications.js
+++ b/api/db/populate-notifications.js
@@ -51,41 +51,81 @@ const getNewComment = (user) => {
   return comments[Math.floor(Math.random() * comments.length)];
 };
 
-const getNewMessage = (user) => {};
+const getNewFriendRequest = (user) => {
+  const friendships = friendshipsList.filter((friendship) => {
+    return (
+      !friendship.accepted &&
+      friendship.receivant.toString() === user._id.toString()
+    );
+  });
+  return friendships[Math.floor(Math.random() * friendships.length)];
+};
+
+const getAcceptedFriendRequest = (user) => {
+  const friendships = friendshipsList.filter((friendship) => {
+    return (
+      friendship.accepted &&
+      friendship.requestant.toString() === user._id.toString()
+    );
+  });
+  return friendships[Math.floor(Math.random() * friendships.length)];
+};
+
+const getNewMessage = (user) => {
+  const friendships = friendshipsList.filter((friendship) => {
+    return (
+      friendship.requestant.toString() === user._id.toString() ||
+      friendship.receivant.toString() === user._id.toString()
+    );
+  });
+  const friendship =
+    friendships[Math.floor(Math.random() * friendships.length)];
+  const messages = messagesList.filter((message) => {
+    return (
+      message.friendship.toString() === friendship._id.toString() &&
+      message.user.toString() !== user._id.toString()
+    );
+  });
+  return messages[Math.floor(Math.random() * messages.length)];
+};
 
 const createNotification = async (notificationParams) => {
   const notification = new Notification({
     user: notificationParams.user,
     type: notificationParams.type,
-    referencedUser: notificationParams.referencedUser,
-    referencedEvent: notificationParams.referencedEvent,
-    referencedFriendship: notificationParams.referencedFriendship,
     read: notificationParams.read,
-    readAt: notificationParams.readAt,
   });
 
   switch (notification.type) {
-    // case types[0]:
-    //   const attendee = getNewAttendant(notification.user);
-    //   if (!attendee) return;
-    //   notification.referencedUser = attendee.user;
-    //   notification.referencedEvent = attendee.event;
-    //   break;
-    // case types[1]:
-    //   const comment = getNewComment(notification.user);
-    //   if (!comment) return;
-    //   notification.referencedUser = comment.user;
-    //   notification.referencedEvent = comment.event;
-    //   break;
-    // case types[2]:
-    //   // new friend request
-    //   break;
-    // case types[3]:
-    //   // accepted friend request
-    //   break;
+    case types[0]:
+      const attendee = getNewAttendant(notification.user);
+      if (!attendee) return;
+      notification.referencedUser = attendee.user;
+      notification.referencedEvent = attendee.event;
+      break;
+    case types[1]:
+      const comment = getNewComment(notification.user);
+      if (!comment) return;
+      notification.referencedUser = comment.user;
+      notification.referencedEvent = comment.event;
+      break;
+    case types[2]:
+      const friendRequest = getNewFriendRequest(notification.user);
+      if (!friendRequest) return;
+      notification.referencedUser = friendRequest.requestant;
+      notification.referencedFriendship = friendRequest;
+      break;
+    case types[3]:
+      const acceptedFriendRequest = getAcceptedFriendRequest(notification.user);
+      if (!acceptedFriendRequest) return;
+      notification.referencedUser = acceptedFriendRequest.receivant;
+      notification.referencedFriendship = acceptedFriendRequest;
+      break;
     case types[4]:
-      // new message
-      const message = getNewMessage(user);
+      const message = getNewMessage(notification.user);
+      if (!message) return;
+      notification.referencedUser = message.user;
+      notification.referencedFriendship = message.friendship;
       break;
     default:
       return;
@@ -96,7 +136,6 @@ const createNotification = async (notificationParams) => {
   if (displayLogs) {
     console.log('\n', '\x1b[0m', `New notification created: ${notification}`);
   }
-  console.log('Notification:', notification);
   return notification;
 };
 
@@ -129,15 +168,6 @@ const createNotifications = async (verbose) => {
     }
   }
 
-  // For each user
-  // create between 0 and 4 notifications
-  // types: [
-  //   newAttendant => referencedUser,
-  //   newComment => referencedUser,
-  //   newFriendshipRequest => referencedFriendship,
-  //   acceptedFriendshipRequest => referencedFriendship,
-  //   newMessage => referencedFriendship (= requestant)
-  // ]
   console.log('\x1b[32m', `Created ${notificationsArray.length} notifications`);
 };
 

--- a/api/db/populate-notifications.js
+++ b/api/db/populate-notifications.js
@@ -1,0 +1,66 @@
+const User = require('../models/User');
+const Attendant = require('../models/Attendant');
+const Friendship = require('../models/Friendship');
+const Message = require('../models/Message');
+const Notifification = require('../models/Notification');
+
+let displayLogs;
+const types = [
+  'newAttendant',
+  'newComment',
+  'newFriendshipRequest',
+  'acceptedFriendshipRequest',
+  'newMessage',
+];
+
+const createNotification = async (notificationParams) => {
+  const notification = new Notification({
+    user: notificationParams.user,
+    type: notificationParams.type,
+    referencedUser: notificationParams.referencedUser,
+    referencedEvent: notificationParams.referencedEvent,
+    referencedFriendship: notificationParams.referencedFriendship,
+    read: notificationParams.read,
+    readAt: notificationParams.readAt,
+  });
+  notification.save();
+
+  if (displayLogs) {
+    console.log('\n', '\x1b[0m', `New notification created: ${notification}`);
+  }
+  return notification;
+};
+
+const createNotifications = async (verbose) => {
+  console.log('\n', '\x1b[0m', 'Populating notifications collection...');
+  displayLogs = verbose;
+
+  const usersList = await User.find();
+  const attendantsList = await Attendant.find();
+  const friendshipsList = await Friendship.find();
+  const messagesList = await Message.find();
+
+  for (const user of usersList) {
+    const notificationsCount = Math.floor(Math.random() * 5);
+
+    for (let i = 0; i < notificationsCount; i++) {
+      const type = types[Math.floor(Math.random() * types.length)];
+      const notificationParams = {
+        user,
+        type,
+      };
+    }
+  }
+
+  // For each user
+  // create between 0 and 4 notifications
+  // types: [
+  //   newAttendant => referencedUser,
+  //   newComment => referencedUser,
+  //   newFriendshipRequest => referencedFriendship,
+  //   acceptedFriendshipRequest => referencedFriendship,
+  //   newMessage => referencedFriendship (= requestant)
+  // ]
+};
+
+module.exports = { createNotifications };

--- a/api/db/populate-notifications.js
+++ b/api/db/populate-notifications.js
@@ -15,7 +15,6 @@ const notificationTypes = [
 const createNotification = async (notificationParams, verbose = false) => {
   const notification = new Notification(notificationParams);
   if (notification.read) notification.readAt = new Date();
-
   await notification.save();
 
   if (verbose) {
@@ -24,4 +23,4 @@ const createNotification = async (notificationParams, verbose = false) => {
   return notification;
 };
 
-module.exports = { createNotification, notificationTypes };
+module.exports = { notificationTypes, createNotification };

--- a/api/db/populate-notifications.js
+++ b/api/db/populate-notifications.js
@@ -27,9 +27,9 @@ const createNotification = async (notificationParams) => {
 
   await notification.save();
 
-  if (displayLogs) {
-    console.log('\n', '\x1b[0m', `New notification created: ${notification}`);
-  }
+  // if (displayLogs) {
+  //   console.log('\n', '\x1b[0m', `New notification created: ${notification}`);
+  // }
   return notification;
 };
 
@@ -204,4 +204,4 @@ const createNotifications = async (verbose) => {
   console.log('\x1b[32m', `Created ${notificationsArray.length} notifications`);
 };
 
-module.exports = { createNotifications };
+module.exports = { createNotification, createNotifications };

--- a/api/db/populate-notifications.js
+++ b/api/db/populate-notifications.js
@@ -1,3 +1,5 @@
+const { createPrompt } = require('./utils');
+
 const User = require('../models/User');
 const Interest = require('../models/Interest');
 const Event = require('../models/Event');
@@ -47,6 +49,20 @@ const createNotification = async (notificationParams) => {
 const createNotifications = async (verbose) => {
   console.log('\n', '\x1b[0m', 'Populating notifications collection...');
   displayLogs = verbose;
+
+  if ((await Notification.countDocuments()) !== 0) {
+    const proceed = await createPrompt(
+      'The notifications collection already exists. If you continue, the existing collection will be dropped to avoid duplication. Do you want to continue?'
+    );
+
+    if (proceed) {
+      await Notification.collection.drop();
+      console.log('\x1b[31m', 'Dropped old notifications collection');
+    } else {
+      console.log('\x1b[33m', 'Aborted notifications collection population');
+      return;
+    }
+  }
 
   const notificationsArray = [];
   const usersList = await User.find();

--- a/api/db/populate-users.js
+++ b/api/db/populate-users.js
@@ -6,7 +6,10 @@ const {
   getRandomSubset,
 } = require('./utils');
 const { uniqueNamesGenerator, names } = require('unique-names-generator');
-const { createNotification } = require('./populate-notifications');
+const {
+  createNotification,
+  notificationTypes,
+} = require('./populate-notifications');
 
 const User = require('../models/User');
 const Interest = require('../models/Interest');
@@ -26,25 +29,25 @@ const createUser = async (userParams) => {
   // Confirm email notification
   await createNotification({
     user,
-    type: 'confirmEmail',
+    type: notificationTypes[0],
     read: user.emailConfirmed,
   });
   // Create event notification
   await createNotification({
     user,
-    type: 'createEvent',
+    type: notificationTypes[1],
     read: false,
   });
   // Upload avatar notification
   await createNotification({
     user,
-    type: 'uploadAvatar',
+    type: notificationTypes[2],
     read: user.avatar ? true : false,
   });
   // Select interests notification
   await createNotification({
     user,
-    type: 'selectInterests',
+    type: notificationTypes[3],
     read: user.interests.length > 0,
   });
 

--- a/api/db/populate-users.js
+++ b/api/db/populate-users.js
@@ -140,10 +140,9 @@ const createUsers = async (multiplier, randomLocation, verbose) => {
     usersArray.push(await createUser(userParams));
   }
 
-  console.log('\x1b[32m', `Created ${usersArray.length} regular users`);
   console.log(
     '\x1b[32m',
-    `Created ${notificationsCount} notifications related to creation of a new user`
+    `Created ${usersArray.length} regular users (and ${notificationsCount} related notifications)`
   );
 };
 

--- a/api/db/populate-users.js
+++ b/api/db/populate-users.js
@@ -16,6 +16,7 @@ const Interest = require('../models/Interest');
 
 const locales = ['en', 'es'];
 let displayLogs;
+let notificationsCount = 0;
 
 const createUser = async (userParams) => {
   const user = new User(userParams);
@@ -62,6 +63,7 @@ const createUser = async (userParams) => {
     },
     displayLogs
   );
+  notificationsCount += 4;
 
   return user;
 };
@@ -139,6 +141,10 @@ const createUsers = async (multiplier, randomLocation, verbose) => {
   }
 
   console.log('\x1b[32m', `Created ${usersArray.length} regular users`);
+  console.log(
+    '\x1b[32m',
+    `Created ${notificationsCount} notifications related to creation of a new user`
+  );
 };
 
 module.exports = { createUsers };

--- a/api/db/populate-users.js
+++ b/api/db/populate-users.js
@@ -142,7 +142,7 @@ const createUsers = async (multiplier, randomLocation, verbose) => {
 
   console.log(
     '\x1b[32m',
-    `Created ${usersArray.length} regular users (and ${notificationsCount} related notifications)`
+    `Created ${usersArray.length} users (and ${notificationsCount} related notifications)`
   );
 };
 

--- a/api/db/populate-users.js
+++ b/api/db/populate-users.js
@@ -27,29 +27,41 @@ const createUser = async (userParams) => {
   }
 
   // Confirm email notification
-  await createNotification({
-    user,
-    type: notificationTypes[0],
-    read: user.emailConfirmed,
-  });
+  await createNotification(
+    {
+      user,
+      type: notificationTypes[0],
+      read: user.emailConfirmed,
+    },
+    displayLogs
+  );
   // Create event notification
-  await createNotification({
-    user,
-    type: notificationTypes[1],
-    read: false,
-  });
+  await createNotification(
+    {
+      user,
+      type: notificationTypes[1],
+      read: false,
+    },
+    displayLogs
+  );
   // Upload avatar notification
-  await createNotification({
-    user,
-    type: notificationTypes[2],
-    read: user.avatar ? true : false,
-  });
+  await createNotification(
+    {
+      user,
+      type: notificationTypes[2],
+      read: user.avatar ? true : false,
+    },
+    displayLogs
+  );
   // Select interests notification
-  await createNotification({
-    user,
-    type: notificationTypes[3],
-    read: user.interests.length > 0,
-  });
+  await createNotification(
+    {
+      user,
+      type: notificationTypes[3],
+      read: user.interests.length > 0,
+    },
+    displayLogs
+  );
 
   return user;
 };

--- a/api/db/populate-users.js
+++ b/api/db/populate-users.js
@@ -134,7 +134,7 @@ const createUsers = async (multiplier, randomLocation, verbose) => {
       dateOfBirth: getRandomDate(
         new Date(1970, 0, 1),
         new Date().setFullYear(now.getFullYear() - 13)
-      ),
+      ).setUTCHours(0, 0, 0, 0),
       interests: getRandomSubset(interestsList, interestsList.length),
       admin: false,
     };

--- a/api/db/populate-users.js
+++ b/api/db/populate-users.js
@@ -68,8 +68,8 @@ const createUser = async (userParams) => {
   return user;
 };
 
-const createAdminUser = () => {
-  createUser({
+const createAdminUser = async () => {
+  await createUser({
     name: 'Admin',
     email: `admin@tisn.app`,
     emailConfirmed: true,
@@ -111,7 +111,9 @@ const createUsers = async (multiplier, randomLocation, verbose) => {
     }
   }
 
-  if (!(await User.exists({ email: 'admin@tisn.app' }))) createAdminUser();
+  if (!(await User.exists({ email: 'admin@tisn.app' }))) {
+    usersArray.push(await createAdminUser());
+  }
 
   for (let i = 0; i < 10 * multiplier; i++) {
     const name = uniqueNamesGenerator({

--- a/api/db/populate-users.js
+++ b/api/db/populate-users.js
@@ -77,7 +77,7 @@ const createAdminUser = async () => {
     country: 'ES',
     region: 'M',
     preferredLocale: 'en',
-    dateOfBirth: new Date(2000, 0, 1),
+    dateOfBirth: new Date(2000, 0, 1, 0, 0, 0, 0),
     interests: [],
     admin: true,
   });

--- a/api/db/populate.js
+++ b/api/db/populate.js
@@ -8,6 +8,7 @@ const { createEvents } = require('./populate-events');
 const { createFriendships } = require('./populate-friendships');
 const { createInterests } = require('./populate-interests');
 const { createMessages } = require('./populate-messages');
+const { createNotifications } = require('./populate-notifications');
 const { createUsers } = require('./populate-users');
 
 const userArgs = minimist(process.argv.slice(2), {
@@ -32,6 +33,7 @@ const populateCollections = async () => {
   await createComments(userArgs.v);
   await createFriendships(userArgs.v);
   await createMessages(userArgs.v);
+  await createNotifications(userArgs.v);
   closeDb();
 };
 
@@ -59,9 +61,12 @@ const populateCollection = async () => {
     case 'messages':
       await createMessages(userArgs.v);
       break;
+    case 'notifications':
+      await createNotifications(userArgs.v);
+      break;
     default:
       console.log(
-        `Unknown collection '${userArgs.c}', possible options are: [interests, users, events, attendants, comments, friendships, messages]`
+        `Unknown collection '${userArgs.c}', possible options are: [interests, users, events, attendants, comments, friendships, messages, notifications]`
       );
       break;
   }

--- a/api/db/populate.js
+++ b/api/db/populate.js
@@ -61,7 +61,7 @@ const populateCollection = async () => {
       break;
     default:
       console.log(
-        `Unknown collection '${userArgs.c}', possible options are: [interests, users, events, attendants, comments, friendships, messages, notifications]`
+        `Unknown collection '${userArgs.c}', possible options are: [interests, users, events, attendants, comments, friendships, messages]`
       );
       break;
   }

--- a/api/db/populate.js
+++ b/api/db/populate.js
@@ -8,7 +8,6 @@ const { createEvents } = require('./populate-events');
 const { createFriendships } = require('./populate-friendships');
 const { createInterests } = require('./populate-interests');
 const { createMessages } = require('./populate-messages');
-const { createNotifications } = require('./populate-notifications');
 const { createUsers } = require('./populate-users');
 
 const userArgs = minimist(process.argv.slice(2), {
@@ -33,7 +32,6 @@ const populateCollections = async () => {
   await createComments(userArgs.v);
   await createFriendships(userArgs.v);
   await createMessages(userArgs.v);
-  await createNotifications(userArgs.v);
   closeDb();
 };
 
@@ -60,9 +58,6 @@ const populateCollection = async () => {
       break;
     case 'messages':
       await createMessages(userArgs.v);
-      break;
-    case 'notifications':
-      await createNotifications(userArgs.v);
       break;
     default:
       console.log(


### PR DESCRIPTION
Closes #279.

You might have a lot to say about this one... 😅 I tried to clean it up as best I could, but it is a pretty complex script. 

Also, as discussed in Slack, it might be worth considering not including this in the standard `npm run db:populate` command as this is a pretty pricey script to run. And it is something that is already slightly tested just when signing up.

Also, I didn't include the first four types in the Notifications enum because it is easier to test that by just signing up a new user. And most of those have already been done just by virtue of running the populate script.